### PR TITLE
Replace `Timing` header with `X-Runtime`

### DIFF
--- a/lib/jets/server/timing_middleware.rb
+++ b/lib/jets/server/timing_middleware.rb
@@ -1,16 +1,33 @@
 class Jets::Server
   class TimingMiddleware
+    FORMAT_STRING = "%0.6f" # :nodoc:
+    HEADER_NAME = "X-Runtime" # :nodoc:
+
     def initialize(app)
       @app = app
     end
 
     def call(env)
-      before = Time.now.to_i
+      start_time = clock_time
       status, headers, body = @app.call(env)
-      after = Time.now.to_i
-      log_message = "App took #{after - before} seconds.\n"
-      headers["Timing"] = "App took #{after - before} seconds.\n"
+      request_time = clock_time - start_time
+
+      unless headers.has_key?(HEADER_NAME)
+        headers[HEADER_NAME] = FORMAT_STRING % request_time
+      end
+
       [status, headers, body]
+    end
+
+    private
+    if defined?(Process::CLOCK_MONOTONIC)
+      def clock_time
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+    else
+      def clock_time
+        Time.now.to_f
+      end
     end
   end
 end


### PR DESCRIPTION
Rack uses `X-Runtime` header to report request runtime. 

Also it uses `CLOCK_MONOTONIC` if available, to ensure that there no ntp-related artifacts in time measurements.