### PR TITLE
Don't fail if AWS credentials are missing

### DIFF
--- a/lib/jets/aws_info.rb
+++ b/lib/jets/aws_info.rb
@@ -48,7 +48,11 @@ module Jets
       return '123456789' if test?
       # ensure region set, required for sts.get_caller_identity.account to work
       ENV['AWS_REGION'] ||= region
-      sts.get_caller_identity.account
+      begin
+        sts.get_caller_identity.account
+      rescue Aws::Errors::MissingCredentialsError
+        puts "INFO: You're missing AWS credentials. Only local services are currently available"
+      end
     end
     memoize :account
 


### PR DESCRIPTION
Fixes #60