### PR TITLE
Fix notice when aws cli is not installed

### DIFF
--- a/lib/jets/aws_info.rb
+++ b/lib/jets/aws_info.rb
@@ -48,7 +48,11 @@ module Jets
       return '123456789' if test?
       # ensure region set, required for sts.get_caller_identity.account to work
       ENV['AWS_REGION'] ||= region
-      sts.get_caller_identity.account
+      begin
+        sts.get_caller_identity.account
+      rescue Aws::Errors::MissingCredentialsError
+        puts "INFO: You're missing AWS credentials. Only local services are currently available"
+      end
     end
     memoize :account
 

--- a/lib/jets/aws_info.rb
+++ b/lib/jets/aws_info.rb
@@ -12,22 +12,25 @@ module Jets
 
       region = nil
 
-      # First try to get it from the ~/.aws/config
-      region = `aws configure get region 2>&1`.strip rescue nil
-      exit_code = $?.exitstatus
-      if exit_code != 0
-        exception_message = region.split("\n").grep(/botocore\.exceptions/).first
-        if exception_message
-          puts "WARN: #{exception_message}".colorize(:yellow)
-        else
-          # show full message as warning
-          puts region.colorize(:yellow)
+      # First if aws binary is available
+      # try to get it from the ~/.aws/config
+      if which('aws')
+        region = `aws configure get region 2>&1`.strip rescue nil
+        exit_code = $?.exitstatus
+        if exit_code != 0
+          exception_message = region.split("\n").grep(/botocore\.exceptions/).first
+          if exception_message
+            puts "WARN: #{exception_message}".colorize(:yellow)
+          else
+            # show full message as warning
+            puts region.colorize(:yellow)
+          end
+          puts "You can also get rid of this message by setting AWS_REGION or configuring ~/.aws/config with the region"
+          region = nil
         end
-        puts "You can also get rid of this message by setting AWS_REGION or configuring ~/.aws/config with the region"
-        region = nil
+        region = nil if region == ''
+        return region if region
       end
-      region = nil if region == ''
-      return region if region
 
       # Second try the metadata endpoint, should be available on AWS Lambda environment
       # https://stackoverflow.com/questions/4249488/find-region-from-within-an-ec2-instance
@@ -78,6 +81,24 @@ module Jets
 
     def test?
       ENV['TEST'] || ENV['CIRCLECI']
+    end
+
+    private
+
+    # Cross-platform way of finding an executable in the $PATH.
+    #
+    #   which('ruby') #=> /usr/bin/ruby
+    #
+    # source: https://stackoverflow.com/questions/2108727/which-in-ruby-checking-if-program-exists-in-path-from-ruby
+    def which(cmd)
+      exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
+      ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
+        exts.each { |ext|
+          exe = File.join(path, "#{cmd}#{ext}")
+          return exe if File.executable?(exe) && !File.directory?(exe)
+        }
+      end
+      return nil
     end
   end
 end


### PR DESCRIPTION
Removes annoying `sh: 1: aws not found` message when aws cli is not available in PATH.

Before
```
$ bundle exec jets server
sh: 1: aws: not found
You can also get rid of this message by setting AWS_REGION or configuring ~/.aws/config with the region
=> bundle exec shotgun --port 8888 --host 127.0.0.1
Jets booting up in development mode!
Jets::Rack#start
== Shotgun/WEBrick on http://127.0.0.1:8888/
[2018-11-05 18:25:35] INFO  WEBrick 1.4.2
[2018-11-05 18:25:35] INFO  ruby 2.5.3 (2018-10-18) [x86_64-linux]
[2018-11-05 18:25:35] INFO  WEBrick::HTTPServer#start: pid=722 port=8888
```
After:
```
$ bundle exec jets server
=> bundle exec shotgun --port 8888 --host 127.0.0.1
Jets booting up in development mode!
Jets::Rack#start
== Shotgun/WEBrick on http://127.0.0.1:8888/
[2018-11-05 18:25:35] INFO  WEBrick 1.4.2
[2018-11-05 18:25:35] INFO  ruby 2.5.3 (2018-10-18) [x86_64-linux]
[2018-11-05 18:25:35] INFO  WEBrick::HTTPServer#start: pid=722 port=8888
```