### PR TITLE
Fix notice when Jets fails to create first git commit

### DIFF
--- a/lib/jets/aws_info.rb
+++ b/lib/jets/aws_info.rb
@@ -48,9 +48,12 @@ module Jets
       return '123456789' if test?
       # ensure region set, required for sts.get_caller_identity.account to work
       ENV['AWS_REGION'] ||= region
-      sts.get_caller_identity.account
+      begin
+        sts.get_caller_identity.account
+      rescue Aws::Errors::MissingCredentialsError
+        puts "INFO: You're missing AWS credentials. Only local services are currently available"
+      end
     end
-    memoize :account
 
     # If bucket does not exist, do not use the cache value and check for the bucket again.
     # This is because we can build the app before deploying it for the first time.

--- a/lib/jets/aws_info.rb
+++ b/lib/jets/aws_info.rb
@@ -57,6 +57,7 @@ module Jets
         puts "INFO: You're missing AWS credentials. Only local services are currently available"
       end
     end
+    memoize :account
 
     # If bucket does not exist, do not use the cache value and check for the bucket again.
     # This is because we can build the app before deploying it for the first time.

--- a/lib/jets/commands/new.rb
+++ b/lib/jets/commands/new.rb
@@ -105,6 +105,7 @@ JS
       return if !options[:git]
       return unless git_installed?
       return if File.exist?(".git") # this is a clone repo
+      return unless git_credentials_set?
 
       run("git init")
       run("git add .")

--- a/lib/jets/commands/sequence.rb
+++ b/lib/jets/commands/sequence.rb
@@ -72,6 +72,13 @@ private
     system("type git > /dev/null 2>&1")
   end
 
+  # In order to automatically create first commit
+  # the user needs to have their credentials set
+  def git_credentials_set?
+    configs = `git config --list`.split("\n")
+    configs.any? { |c| c.start_with? 'user.name=' } && configs.any? { |c| c.start_with? 'user.email=' }
+  end
+
   def yarn_installed?
     system("type yarn > /dev/null 2>&1")
   end


### PR DESCRIPTION
This removes notice from git when name&email are not available in git config:
```
...
Done in 4.67s.
         run  git init from "."
Initialized empty Git repository in /tmp/test-project/.git/
         run  git add . from "."
         run  git commit -m 'first commit' from "."

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'root@dcd54d225d69.(none)')
================================================================
Congrats 🎉 You have successfully created a Jets project.

Cd into the project directory:
  cd test-project

To start a server and test locally:
  jets server # localhost:8888 should have the Jets welcome page

Scaffold example:
  jets generate scaffold Post title:string body:text published:boolean

To deploy to AWS Lambda, edit your .env.development.remote and add a DATABASE_URL endpoint.
Then run:

  jets deploy
```