### PR TITLE
Add option to specify authorization type on a per-route basis.

### DIFF
--- a/docs/_docs/routing.md
+++ b/docs/_docs/routing.md
@@ -34,6 +34,17 @@ You can check the routes on the API Gateway console:
 
 ![](/img/quick-start/demo-api-gateway.png)
 
+##Authorization
+By default, each route specified will not require any authorization in order to call it.
+You can choose to enable authorization on a per-route basis:
+```ruby
+Jets.application.routes.draw do
+  get  "posts", to: "posts#index", authorization_type: "AWS_IAM"
+end
+```
+This will require a caller to authenticate using IAM before being able to access the endpoint.
+The complete list of authorization types is available in the [AWS API Gateway docs](https://docs.aws.amazon.com/apigateway/api-reference/resource/method/#authorizationType).
+
 ## jets routes
 
 You can also check the routes with the `jets routes` cli command. Here's an example:

--- a/lib/jets/resource/api_gateway/cors.rb
+++ b/lib/jets/resource/api_gateway/cors.rb
@@ -10,7 +10,7 @@ module Jets::Resource::ApiGateway
           properties: {
             resource_id: "!Ref #{resource_id}",
             rest_api_id: "!Ref RestApi",
-            authorization_type: "NONE",
+            authorization_type: authorization_type,
             http_method: "OPTIONS",
             method_responses: [{
               status_code: '200',

--- a/lib/jets/resource/api_gateway/method.rb
+++ b/lib/jets/resource/api_gateway/method.rb
@@ -21,7 +21,7 @@ module Jets::Resource::ApiGateway
             rest_api_id: "!Ref RestApi",
             http_method: @route.method,
             request_parameters: {},
-            authorization_type: "NONE",
+            authorization_type: authorization_type,
             integration: {
               integration_http_method: "POST",
               type: "AWS_PROXY",
@@ -64,6 +64,11 @@ module Jets::Resource::ApiGateway
     memoize :cors
 
   private
+
+    def authorization_type
+      @route.authorization_type || "NONE"
+    end
+
     def resource_id
       @route.path == '' ?
        "RootResourceId" :

--- a/lib/jets/route.rb
+++ b/lib/jets/route.rb
@@ -120,6 +120,10 @@ class Jets::Route
     { key => value }
   end
 
+  def authorization_type
+    @options[:authorization_type]
+  end
+
 private
   def ensure_jets_format(path)
     path.split('/').map do |s|

--- a/spec/lib/jets/resource/api_gateway/cors_spec.rb
+++ b/spec/lib/jets/resource/api_gateway/cors_spec.rb
@@ -13,6 +13,19 @@ describe Jets::Resource::ApiGateway::Cors do
       expect(properties["ResourceId"]).to eq "!Ref PostsApiResource"
       expect(properties["HttpMethod"]).to eq "OPTIONS"
     end
+
+    it 'defaults to no authorization' do
+      expect(resource.properties["AuthorizationType"]).to eq 'NONE'
+    end
+  end
+
+  context "authorization" do
+    let(:route) do
+      Jets::Route.new(path: "posts", method: :get, to: "posts#index", authorization_type: 'AWS_IAM')
+    end
+    it "can specify an authorization type" do
+      expect(resource.properties["AuthorizationType"]).to eq 'AWS_IAM'
+    end
   end
 end
 

--- a/spec/lib/jets/resource/api_gateway/method_spec.rb
+++ b/spec/lib/jets/resource/api_gateway/method_spec.rb
@@ -6,12 +6,25 @@ describe Jets::Resource::ApiGateway::Method do
       Jets::Route.new(path: "posts", method: :get, to: "posts#index")
     end
     it "resource" do
-      expect(resource.logical_id).to eq "PostsGetApiMethod"
+      expect(resource.logical_id).to eq "PostsIndexApiMethod"
       properties = resource.properties
       # pp properties # uncomment to debug
       expect(properties["RestApiId"]).to eq "!Ref RestApi"
       expect(properties["ResourceId"]).to eq "!Ref PostsApiResource"
       expect(properties["HttpMethod"]).to eq "GET"
+    end
+
+    it 'defaults to no authorization' do
+      expect(resource.properties["AuthorizationType"]).to eq 'NONE'
+    end
+  end
+
+  context "authorization" do
+    let(:route) do
+      Jets::Route.new(path: "posts", method: :get, to: "posts#index", authorization_type: 'AWS_IAM')
+    end
+    it "can specify an authorization type" do
+      expect(resource.properties["AuthorizationType"]).to eq 'AWS_IAM'
     end
   end
 end

--- a/spec/lib/jets/route_spec.rb
+++ b/spec/lib/jets/route_spec.rb
@@ -129,4 +129,18 @@ describe "Route" do
       expect(jets_format).to eq "others/*proxy"
     end
   end
+
+  context "route with authorization controls" do
+    let(:route) do
+      Jets::Route.new(path: "posts", method: :get, to: "posts#index", authorization_type: 'AWS_IAM')
+    end
+
+    it 'authorization can be specified' do
+      expect(route.authorization_type).to eq 'AWS_IAM'
+    end
+
+    it 'authorization can be nil' do
+      expect(Jets::Route.new(path: "posts", method: :get, to: "posts#index").authorization_type).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
By default, each endpoint has an authorization type of NONE. This isn't very suitable for a lot of private APIs being built, so adding in the ability to customise. Updated documentation to show how to use it.

Testing:
- Added new spec tests, and ran existing ones. I noticed that some of the existing tests weren't running as part of a standard rspec call, and as a result an existing tests was broken (which I fixed).
- Ran "jets deploy" for a project containing routes both with and without authorization types and confirmed they were created correctly in AWS.