### PR TITLE
ApiGateway config.api.endpoint_type option

### DIFF
--- a/docs/_docs/app-config.md
+++ b/docs/_docs/app-config.md
@@ -32,10 +32,11 @@ Jets.application.configure do
   #   security_group_ids: [ "sg-1", "sg-2" ],
   #   subnet_ids: [ "subnet-1", "subnet-2" ]
   # }
-  # config.endpoint_type = 'PRIVATE' # Default is 'EDGE' (https://docs.aws.amazon.com/apigateway/api-reference/link-relation/restapi-create/#endpointConfiguration) 
   # The config.function settings to the CloudFormation Lambda Function properties.
   # http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html
   # Underscored format can be used for keys to make it look more ruby-ish.
+  
+  # config.api.endpoint_type = 'PRIVATE' # Default is 'EDGE' (https://docs.aws.amazon.com/apigateway/api-reference/link-relation/restapi-create/#endpointConfiguration) 
 end
 ```
 

--- a/lib/jets/application.rb
+++ b/lib/jets/application.rb
@@ -78,6 +78,9 @@ class Jets::Application
     config.session.store = Rack::Session::Cookie # note when accessing it use session[:store] since .store is an OrderedOptions method
     config.session.options = {}
 
+    config.api = ActiveSupport::OrderedOptions.new
+    config.api.endpoint_type = 'EDGE' # PRIVATE, EDGE, REGIONAL
+
     config
   end
 

--- a/lib/jets/cfn/builders/api_gateway_builder.rb
+++ b/lib/jets/cfn/builders/api_gateway_builder.rb
@@ -28,7 +28,7 @@ class Jets::Cfn::Builders
 
     # If the are routes in config/routes.rb add Gateway API in parent stack
     def add_gateway_rest_api
-      rest_api = Jets::Resource::ApiGateway::RestApi.new(endpoint_type: Jets.config.endpoint_type)
+      rest_api = Jets::Resource::ApiGateway::RestApi.new
       add_resource(rest_api)
       add_outputs(rest_api.outputs)
 

--- a/lib/jets/commands/templates/skeleton/config/application.rb.tt
+++ b/lib/jets/commands/templates/skeleton/config/application.rb.tt
@@ -24,7 +24,7 @@ Jets.application.configure do
   # config.function.role = "arn:aws:iam::#{Jets.aws.account}:role/service-role/pre-created"
   # config.function.memory_size = 1536
 
-  # config.endpoint_type = 'PRIVATE' # Default is 'EDGE' (https://docs.aws.amazon.com/apigateway/api-reference/link-relation/restapi-create/#endpointConfiguration)
+  # config.api.endpoint_type = 'PRIVATE' # Default is 'EDGE' (https://docs.aws.amazon.com/apigateway/api-reference/link-relation/restapi-create/#endpointConfiguration)
 
   # config.function.environment = {
   #   global_app_key1: "global_app_value1",

--- a/lib/jets/resource/api_gateway/rest_api.rb
+++ b/lib/jets/resource/api_gateway/rest_api.rb
@@ -1,10 +1,6 @@
 module Jets::Resource::ApiGateway
   class RestApi < Jets::Resource::Base
 
-    def initialize(options)
-      @options = options
-    end
-
     def definition
       {
         rest_api: {
@@ -12,20 +8,24 @@ module Jets::Resource::ApiGateway
           properties: {
             name: Jets::Naming.gateway_api_name,
             endpoint_configuration: {
-              types: [@options[:endpoint_type] || 'EDGE']
+              types: types
             }
             # binary_media_types: ['*/*'], # TODO: comment out, breaking form post
           }
         }
       }
     end
-
+    
     def outputs
       {
         "RestApi" => "!Ref RestApi",
         "Region" => "!Ref AWS::Region",
         "RootResourceId" => "!GetAtt RestApi.RootResourceId",
       }
+    end
+
+    def types
+      [Jets.config.api.endpoint_type || 'EDGE']
     end
   end
 end

--- a/spec/lib/jets/resource/api_gateway/rest_api_spec.rb
+++ b/spec/lib/jets/resource/api_gateway/rest_api_spec.rb
@@ -1,12 +1,18 @@
 describe Jets::Resource::ApiGateway::RestApi do
 
   context 'endpoint configuration' do
+    let(:types) do
+      Jets::Resource::ApiGateway::RestApi.new.properties["EndpointConfiguration"]["Types"]
+    end
+    
     it 'defaults to edge-optimized' do
-      expect(Jets::Resource::ApiGateway::RestApi.new(endpoint_type: nil).properties["EndpointConfiguration"]["Types"][0]).to eq 'EDGE'
+      allow(Jets.config.api).to receive(:endpoint_type).and_return(nil)
+      expect(types).to eq ['EDGE']
     end
 
     it 'can be set explicitly' do
-      expect(Jets::Resource::ApiGateway::RestApi.new(endpoint_type: 'PRIVATE').properties["EndpointConfiguration"]["Types"][0]).to eq 'PRIVATE'
+      allow(Jets.config.api).to receive(:endpoint_type).and_return('PRIVATE')
+      expect(types).to eq ['PRIVATE']
     end
   end
 


### PR DESCRIPTION
related #75, adjust the option to `config.api.endpoint_type`:

Very through description from #75:

ApiGateway supports 3 different endpoint types (edge-optimised, private, and regional). I've kept the default as edge-optimised, but added the ability to configure the type via application configuration. The documentation for these variables seems to be in the example config, so I stuck with doing that.

Testing:
- Added new spec tests, and ran existing ones.
- Ran "jets deploy" for a project specifying an endpoint type and confirmed it was created correctly.
- Ran "jets deploy" for a project not specifying an endpoint type and confirmed it was created as 'EDGE', to preserve existing behaviour.