### PR TITLE
add config.api.authorization_type application-wide option

### DIFF
--- a/docs/_docs/routing.md
+++ b/docs/_docs/routing.md
@@ -34,15 +34,26 @@ You can check the routes on the API Gateway console:
 
 ![](/img/quick-start/demo-api-gateway.png)
 
-##Authorization
-By default, each route specified will not require any authorization in order to call it.
-You can choose to enable authorization on a per-route basis:
+## Authorization
+
+By default, each route does not require any authorization. You can enable authorization application-wide with `config/application.rb`:
+
+```ruby
+Jets.application.configure do
+  config.api.authorization_type = "AWS_IAM"
+end
+```
+
+This will require a caller to authenticate using IAM before being able to access the endpoint.
+
+You can also enable authorization on a per-route basis with the `authorization_type` option:
+
 ```ruby
 Jets.application.routes.draw do
   get  "posts", to: "posts#index", authorization_type: "AWS_IAM"
 end
 ```
-This will require a caller to authenticate using IAM before being able to access the endpoint.
+
 The complete list of authorization types is available in the [AWS API Gateway docs](https://docs.aws.amazon.com/apigateway/api-reference/resource/method/#authorizationType).
 
 ## jets routes

--- a/lib/jets/application.rb
+++ b/lib/jets/application.rb
@@ -79,6 +79,7 @@ class Jets::Application
     config.session.options = {}
 
     config.api = ActiveSupport::OrderedOptions.new
+    config.api.authorization_type = "NONE"
     config.api.endpoint_type = 'EDGE' # PRIVATE, EDGE, REGIONAL
 
     config

--- a/lib/jets/resource/api_gateway/method.rb
+++ b/lib/jets/resource/api_gateway/method.rb
@@ -66,7 +66,8 @@ module Jets::Resource::ApiGateway
   private
 
     def authorization_type
-      @route.authorization_type || "NONE"
+      type = @route.authorization_type || Jets.config.api.authorization_type
+      type.upcase
     end
 
     def resource_id

--- a/lib/jets/resource/api_gateway/rest_api.rb
+++ b/lib/jets/resource/api_gateway/rest_api.rb
@@ -25,7 +25,8 @@ module Jets::Resource::ApiGateway
     end
 
     def types
-      [Jets.config.api.endpoint_type || 'EDGE']
+      endpoint_type = Jets.config.api.endpoint_type || 'EDGE'
+      [endpoint_type.upcase]
     end
   end
 end


### PR DESCRIPTION
Related to #74. Also add `config.api.authorization_type` application-wide option in this PR.

Very through description from #74:

By default, each endpoint has an authorization type of NONE. This isn't very suitable for a lot of private APIs being built, so adding in the ability to customise. Updated documentation to show how to use it.

Testing:
- Added new spec tests, and ran existing ones. I noticed that some of the existing tests weren't running as part of a standard rspec call, and as a result an existing tests was broken (which I fixed).
- Ran "jets deploy" for a project containing routes both with and without authorization types and confirmed they were created correctly in AWS.