### PR TITLE
Fully qualify bundle install path, to fix issue when building on Code…

### DIFF
--- a/lib/jets/builders/ruby_packager.rb
+++ b/lib/jets/builders/ruby_packager.rb
@@ -56,7 +56,7 @@ class Jets::Builders
         # cd /tmp/jets/demo
         sh(
           "cd #{cache_area} && " \
-          "env BUNDLE_IGNORE_CONFIG=1 bundle install --path bundled/gems --without development test"
+          "env BUNDLE_IGNORE_CONFIG=1 bundle install --path #{cache_area}/bundled/gems --without development test"
         )
       end
 


### PR DESCRIPTION
…Build. Fixes #80.

When running jets deploy on CodeBuild, the bundled gems are not being copied to the correct location. That means that the zips that are produced and deployed contain no dependencies, resulting in lots of errors (e.g. "Could not find rake-12.3.1 in any of the sources"). This change fully qualifies the path, as the terminal on CodeBuild does not seem to be observing the cd command. Should be no functional change on existing build systems.
Testing:
- rspec
- Ran jets build and confirmd the zip contained bundled/gems as expected.

https://github.com/tongueroo/jets/issues/80