### PR TITLE
Added SQS RedrivePolicy attributes to special map

### DIFF
--- a/lib/jets/camelizer.rb
+++ b/lib/jets/camelizer.rb
@@ -58,6 +58,8 @@ module Jets
         {
           "TemplateUrl" => "TemplateURL",
           "Ttl" => "TTL",
+          "MaxReceiveCount" => "maxReceiveCount",
+          "DeadLetterQueueArn" => "deadLetterQueueArn",
         }
       end
     end


### PR DESCRIPTION
The SQS RedrivePolicy attributes aren't being camelized properly which results in an AWS API error...
`Value {"MaxReceiveCount":"4","DeadLetterTargetArn":"arn:aws:sqs:us-east-1:********:*************"} for parameter RedrivePolicy is invalid. Reason: Redrive policy does not contain mandatory attribute: maxReceiveCount. (Service: AmazonSQS; Status Code: 400; Error Code: InvalidParameterValue; Request ID: *******)`