### PR TITLE
Change before_action behavior: allow chain break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project *loosely tries* to adhere to [Semantic Versioning](http://semver.org/), even before v1.0.
 
+## [UNRELEASED]
+- Change before_action behavior: When any before action renders or redirects, the filter chain
+  is halted, and action code is not executed. This allows before_action to act as guards.
+
 ## [1.5.1]
 - #137 from tongueroo/gems-check bypass gems check exit for custom lambda layers
 

--- a/lib/jets/controller/base.rb
+++ b/lib/jets/controller/base.rb
@@ -37,10 +37,14 @@ class Jets::Controller
       t1 = Time.now
       log_info_start
 
-      run_before_actions
-      send(@meth)
-      triplet = ensure_render
-      run_after_actions
+      if run_before_actions(break_if: -> { @rendered })
+        send(@meth)
+        triplet = ensure_render
+        run_after_actions
+      else
+        Jets.logger.info "Filter chain halted as #{@last_callback_name} rendered or redirected"
+        triplet = ensure_render
+      end
 
       took = Time.now - t1
       status = triplet[0]

--- a/lib/jets/controller/callbacks.rb
+++ b/lib/jets/controller/callbacks.rb
@@ -20,8 +20,9 @@ class Jets::Controller
 
     # Instance Methods
     # define run_before_actions and run_after_actions
+    # returns true if all actions were run, false if break_if condition yielded `true`
     [:before, :after].each do |type|
-      define_method "run_#{type}_actions" do
+      define_method "run_#{type}_actions" do |break_if: nil|
         called_method = @meth.to_sym
         callbacks = self.class.send("#{type}_actions")
         callbacks.each do |array|
@@ -36,7 +37,11 @@ class Jets::Controller
           else
             send(callback)
           end
+          @last_callback_name = callback
+
+          return false if !break_if.nil? && break_if.call
         end
+        true
       end
     end
   end # ClassOptions

--- a/spec/lib/jets/controller/callbacks_spec.rb
+++ b/spec/lib/jets/controller/callbacks_spec.rb
@@ -8,6 +8,23 @@ class WhateverController < Jets::Controller::Base
   def find_whatever; end
 end
 
+class BreakableController < Jets::Controller::Base
+  before_action :breakable_action
+  before_action :another_action
+
+  def index
+    raise "should not get here"
+  end
+
+  def breakable_action
+    render json: {}, status: 404
+  end
+
+  def another_action
+    raise "should not get here"
+  end
+end
+
 describe Jets::Controller::Base do
   context FakeController do
     let(:controller) { FakeController.new({}, nil, "meth") }
@@ -22,6 +39,16 @@ describe Jets::Controller::Base do
 
     it "before_actions includes find_whatever only" do
       expect(controller.class.before_actions).to eq [[:find_whatever, {}]]
+    end
+  end
+
+  context BreakableController do
+    let(:controller) { BreakableController.new({}, nil, :index) }
+
+    it "breaks before reaching index" do
+      response = controller.dispatch!
+      expect(response[0]).to eq '404'
+      expect(response[2].read).to eq '{}'
     end
   end
 end


### PR DESCRIPTION
- I read the contributing document at https://rubyonjets.com/docs/contributing/

This is a 🙋‍♂️ feature or enhancement.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

Sorry, no documentation changes. Couldn't find Jets documentation about before_action.

## Summary

When any before action renders or redirects, the filter chain
is halted, and the action code is not executed. This allows
before_action to act as guards like in Rails.