### PR TITLE
Fix jets.gemspec files listing method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project *loosely tries* to adhere to [Semantic Versioning](http://semver.org/), even before v1.0.
 
+## [UNRELEASED]
+- Fix jets.gemspec how git command is executed to list files. The listing no longer needs to be done
+  from the jets root directory. This change enables including Jets as local bundler gem.
+
 ## [1.5.1]
 - #137 from tongueroo/gems-check bypass gems check exit for custom lambda layers
 

--- a/jets.gemspec
+++ b/jets.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.rdoc_options += Jets::Rdoc.options
 
   vendor_files       = Dir.glob("vendor/**/*")
-  gem_files          = `git ls-files -z`.split("\x0").reject do |f|
+  gem_files          = `git -C "#{File.dirname(__FILE__)}" ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features|docs)/})
   end
   spec.files         = gem_files + vendor_files


### PR DESCRIPTION
- I read the contributing document at https://rubyonjets.com/docs/contributing/

This is a 🐞 bug fix.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fix jets.gemspec how git command is executed to list files. The listing no longer needs to be done from the jets root directory. This change enables including Jets as local bundler gem.