### PR TITLE
Add configurable Jets.application.config.logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project *loosely tries* to adhere to [Semantic Versioning](http://semver.org/), even before v1.0.
 
+## [UNRELEASED]
+- Add Jets.application.config.logger field to enable custom logger instance to
+  be configured in config/environments/*.rb files.
+
 ## [1.5.1]
 - #137 from tongueroo/gems-check bypass gems check exit for custom lambda layers
 

--- a/lib/jets/application.rb
+++ b/lib/jets/application.rb
@@ -35,6 +35,7 @@ class Jets::Application
     config.cors = true
     config.autoload_paths = default_autoload_paths
     config.extra_autoload_paths = []
+    config.logger = Jets::Logger.new($stderr)
 
     # function properties defaults
     config.function = ActiveSupport::OrderedOptions.new

--- a/lib/jets/commands/templates/skeleton/config/application.rb.tt
+++ b/lib/jets/commands/templates/skeleton/config/application.rb.tt
@@ -58,4 +58,9 @@ Jets.application.configure do
   # us-east-1 EDGE endpoint
   # config.domain.cert_arn = "arn:aws:acm:us-east-1:112233445566:certificate/d68472ba-04f8-45ba-b9db-14f839d57123"
   # config.domain.endpoint_type = "EDGE"
+
+  # By default logger needs to log to $stderr for CloudWatch to receive Lambda messages, but for
+  # local testing environment you may want to log these messages to 'test.log' file to keep your
+  # testing suite output readable.
+  # config.logger = Jets::Logger.new($strerr)
 end

--- a/lib/jets/core.rb
+++ b/lib/jets/core.rb
@@ -42,7 +42,7 @@ module Jets::Core
   memoize :build_root
 
   def logger
-    Jets::Logger.new($stderr)
+    Jets.application.config.logger
   end
   memoize :logger
 


### PR DESCRIPTION
- I read the contributing document at https://rubyonjets.com/docs/contributing/

This is a 🙋‍♂️ feature or enhancement.
This is a 🧐 documentation change (a little).

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Add Jets.application.config.logger field to enable custom logger
instance to be configured in config/environments/*.rb files.