### PR TITLE
Add prepend/append_before/after_action callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project *loosely tries* to adhere to [Semantic Versioning](http://semver.org/), even before v1.0.
 
+## [UNRELEASED]
+- Add prepend/append_before_action and prepend/append_after_action callbacks
+
 ## [1.5.5]
 - #148 check reserved lambda variables and let user know
 

--- a/lib/jets/controller/callbacks.rb
+++ b/lib/jets/controller/callbacks.rb
@@ -9,12 +9,26 @@ class Jets::Controller
       class_attribute :after_actions
       self.after_actions = []
 
-      def self.before_action(meth, options={})
-        self.before_actions += [[meth, options]]
-      end
+      class << self
+        def before_action(meth, options={})
+          self.before_actions += [[meth, options]]
+        end
 
-      def self.after_action(meth, options={})
-        self.after_actions += [[meth, options]]
+        def prepend_before_action(meth, options={})
+          self.before_actions.unshift([meth, options])
+        end
+
+        alias_method :append_before_action, :before_action
+
+        def after_action(meth, options={})
+          self.after_actions += [[meth, options]]
+        end
+
+        def prepend_after_action(meth, options={})
+          self.after_actions.unshift([meth, options])
+        end
+
+        alias_method :append_after_action, :after_action
       end
     end # included
 

--- a/spec/lib/jets/controller/callbacks_spec.rb
+++ b/spec/lib/jets/controller/callbacks_spec.rb
@@ -25,6 +25,22 @@ class BreakableController < Jets::Controller::Base
   end
 end
 
+class PrependAppendBeforeController < Jets::Controller::Base
+  append_before_action :normal
+  prepend_before_action :prepended
+
+  def normal; end
+  def prepended; end
+end
+
+class PrependAppendAfterController < Jets::Controller::Base
+  append_after_action :normal
+  prepend_after_action :prepended
+
+  def normal; end
+  def prepended; end
+end
+
 describe Jets::Controller::Base do
   context FakeController do
     let(:controller) { FakeController.new({}, nil, "meth") }
@@ -49,6 +65,20 @@ describe Jets::Controller::Base do
       response = controller.dispatch!
       expect(response[0]).to eq '404'
       expect(response[2].read).to eq '{}'
+    end
+  end
+
+  context PrependAppendBeforeController do
+    subject { PrependAppendBeforeController.new({}, nil, :index) }
+    it "prepends method" do
+      expect(subject.class.before_actions).to eq [[:prepended, {}], [:normal, {}]]
+    end
+  end
+
+  context PrependAppendAfterController do
+    subject { PrependAppendAfterController.new({}, nil, :index) }
+    it "prepends method" do
+      expect(subject.class.after_actions).to eq [[:prepended, {}], [:normal, {}]]
     end
   end
 end


### PR DESCRIPTION
- I read the contributing document at https://rubyonjets.com/docs/contributing/

This is a 🙋‍♂️ feature or enhancement.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Added these callbacks:

- prepend_before_action
- append_before_action (alias to before_action)
- prepend_after_action
- append_after_action (alias to after_action)
