### PR TITLE
Fix prepend_* callbacks: Global callback array fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project *loosely tries* to adhere to [Semantic Versioning](http://semver.org/), even before v1.0.
 
+## [1.5.7]
+- Fix prepend_* callbacks: These could modify a global callback array if used first
+
 ## [1.5.6]
 - #149 from patchkit-net/feature/prepend-append-callbacks Add prepend/append_before_action and prepend/append_after_action callbacks
 - #150 special s3 url for us-east-1

--- a/lib/jets/controller/callbacks.rb
+++ b/lib/jets/controller/callbacks.rb
@@ -15,7 +15,7 @@ class Jets::Controller
         end
 
         def prepend_before_action(meth, options={})
-          self.before_actions.unshift([meth, options])
+          self.before_actions = [[meth, options]] + self.before_actions
         end
 
         alias_method :append_before_action, :before_action
@@ -25,7 +25,7 @@ class Jets::Controller
         end
 
         def prepend_after_action(meth, options={})
-          self.after_actions.unshift([meth, options])
+          self.after_actions = [[meth, options]] + self.after_actions
         end
 
         alias_method :append_after_action, :after_action

--- a/spec/lib/jets/controller/callbacks_spec.rb
+++ b/spec/lib/jets/controller/callbacks_spec.rb
@@ -1,3 +1,18 @@
+# There was a bug that prepending action modified the global callbacks array throwing a lot of
+# errors in this spec and others
+#
+# If you see unwanted :prepended actions in your callback, it means that prepend_* methods are
+# modifying the global callbacks table.
+class PrependBeforeBugController < Jets::Controller::Base
+  prepend_before_action :prepended
+  def prepended; end
+end
+
+class PrependAfterBugController < Jets::Controller::Base
+  prepend_after_action :prepended
+  def prepended; end
+end
+
 class FakeController < Jets::Controller::Base
   before_action :find_article
   def find_article; end


### PR DESCRIPTION
- I read the contributing document at https://rubyonjets.com/docs/contributing/

This is a 🐞 bug fix.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

These could modify a global callback array if used first