### PR TITLE
Fix invalid path collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project *loosely tries* to adhere to [Semantic Versioning](http://semver.org/), even before v1.0.
 
+## [UNRELEASED]
+- Fix invalid collision detection on paths that already contains path variables
+
 ## [1.5.10]
 - #157 Improve Route Change Detection: Path Variables
 

--- a/lib/jets/resource/api_gateway/rest_api/routes/collision.rb
+++ b/lib/jets/resource/api_gateway/rest_api/routes/collision.rb
@@ -68,6 +68,8 @@ class Jets::Resource::ApiGateway::RestApi::Routes
     end
 
     def parent?(parent, path)
+      return false if parent == path
+
       parent_parts = parent.split('/')
       path_parts = path.split('/')
 

--- a/spec/lib/jets/resource/api_gateway/rest_api/routes/collsion_spec.rb
+++ b/spec/lib/jets/resource/api_gateway/rest_api/routes/collsion_spec.rb
@@ -48,6 +48,21 @@ describe Jets::Resource::ApiGateway::RestApi do
       expect(collide).to be false
     end
 
+    it "variable_collision_exists long path?" do
+      parent_path = "users/:user_id/posts"
+      paths = %w[
+        users/:user_id
+        users/:user_id/posts
+        users/:user_id/posts/:id
+        users/:user_id/posts/:id/edit
+        users/:user_id/apps
+        posts/:id
+        admin
+      ]
+      collide = collision.variable_collision_exists?(parent_path, paths)
+      expect(collide).to be false
+    end
+
     # actual data
     it "variable_collision_exists? post crud" do
       parent_path = "posts"


### PR DESCRIPTION
- I read the contributing document at https://rubyonjets.com/docs/contributing/

This is a 🐞 bug fix.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Collision#parent? method was incorrectly returning true for paths
that were the same causing collision error in some cases.