### PR TITLE
remove pretty iam role name, let CloudFormation generate name

### DIFF
--- a/lib/jets/resource/api_gateway/rest_api/routes/change/base.rb
+++ b/lib/jets/resource/api_gateway/rest_api/routes/change/base.rb
@@ -69,13 +69,37 @@ class Jets::Resource::ApiGateway::RestApi::Routes::Change
     def recreate_to(method_uri)
       md = method_uri.match(/function:(.*)\//)
       function_arn = md[1] # IE: demo-dev-posts_controller-new
-      # TODO: If this hits the Lambda Rate limit, then list_functions also contains the Lambda
-      # function description. So we can paginate through list_functions results and store
-      # description from there if needed.
+      controller, action = get_controller_action(function_arn)
+      "#{controller}##{action}" # IE: posts#new
+    end
+
+    def get_controller_action(function_arn)
+      if function_arn.include?('_controller-')
+        controller_action_from_string(function_arn)
+      else
+        controller_action_from_api(function_arn)
+      end
+    end
+
+    # TODO: If this hits the Lambda Rate limit, then list_functions also contains the Lambda
+    # function description. So we can paginate through list_functions results and store
+    # description from there if needed.
+    # Dont think this will be needed though because controller_action_from_string gets called
+    # most of the time. Also, user might be able to request their Lambda limit to be increased.
+    def controller_action_from_api(function_arn)
       desc = lambda_function_description(function_arn)
       controller, action = desc.split('#')
       controller = controller.underscore.sub(/_controller$/,'')
-      "#{controller}##{action}" # IE: posts#new
+      [controller, action]
+    end
+
+    def controller_action_from_string(function_arn)
+      controller_action = function_arn.sub("#{Jets.project_namespace}-", '')
+      md = controller_action.match(/(.*)_controller-(.*)/)
+      controller = md[1]
+      controller = controller.gsub('-','/')
+      action = md[2]
+      [controller, action]
     end
 
     def lambda_function_description(function_arn)

--- a/lib/jets/resource/api_gateway/rest_api/routes/change/base.rb
+++ b/lib/jets/resource/api_gateway/rest_api/routes/change/base.rb
@@ -72,10 +72,15 @@ class Jets::Resource::ApiGateway::RestApi::Routes::Change
       # TODO: If this hits the Lambda Rate limit, then list_functions also contains the Lambda
       # function description. So we can paginate through list_functions results and store
       # description from there if needed.
-      resp = lambda.get_function(function_name: function_arn)
-      desc = resp.configuration.description # contains full info: PostsController#index
+      desc = lambda_function_description(function_arn)
       controller, action = desc.split('#')
+      controller = controller.underscore.sub(/_controller$/,'')
       "#{controller}##{action}" # IE: posts#new
+    end
+
+    def lambda_function_description(function_arn)
+      resp = lambda.get_function(function_name: function_arn)
+      resp.configuration.description # contains full info: PostsController#index
     end
 
     # Duplicated in rest_api/change_detection.rb, base_path/role.rb, rest_api/routes.rb

--- a/lib/jets/resource/api_gateway/rest_api/routes/change/base.rb
+++ b/lib/jets/resource/api_gateway/rest_api/routes/change/base.rb
@@ -68,12 +68,13 @@ class Jets::Resource::ApiGateway::RestApi::Routes::Change
     #   posts#new
     def recreate_to(method_uri)
       md = method_uri.match(/function:(.*)\//)
-      function_name = md[1] # IE: demo-dev-posts_controller-new
-      controller_action = function_name.sub("#{Jets.project_namespace}-", '')
-      md = controller_action.match(/(.*)_controller-(.*)/)
-      controller = md[1]
-      controller = controller.gsub('-','/')
-      action = md[2]
+      function_arn = md[1] # IE: demo-dev-posts_controller-new
+      # TODO: If this hits the Lambda Rate limit, then list_functions also contains the Lambda
+      # function description. So we can paginate through list_functions results and store
+      # description from there if needed.
+      resp = lambda.get_function(function_name: function_arn)
+      desc = resp.configuration.description # contains full info: PostsController#index
+      controller, action = desc.split('#')
       "#{controller}##{action}" # IE: posts#new
     end
 

--- a/lib/jets/resource/iam/application_role.rb
+++ b/lib/jets/resource/iam/application_role.rb
@@ -14,8 +14,8 @@ module Jets::Resource::Iam
       "iam_role"
     end
 
-    def role_name
-      "#{Jets.config.project_namespace}-application-role"
+    def policy_name
+      "#{Jets.config.project_namespace}-application-policy"
     end
 
     def outputs

--- a/lib/jets/resource/iam/base_role_definition.rb
+++ b/lib/jets/resource/iam/base_role_definition.rb
@@ -5,11 +5,12 @@ module Jets::Resource::Iam
     def definition
       logical_id = role_logical_id
 
+      # Do not assign pretty role_name because long controller names might hit the 64-char
+      # limit. Also, IAM roles are global, so assigning role names prevents cross region deploys.
       definition = {
         logical_id => {
           type: "AWS::IAM::Role",
           properties: {
-            role_name: role_name,
             path: "/",
             assume_role_policy_document: {
               version: "2012-10-17",
@@ -24,7 +25,7 @@ module Jets::Resource::Iam
       }
 
       definition[logical_id][:properties][:policies] = [
-        policy_name: "#{role_name}-policy",
+        policy_name: "#{policy_name[0..127]}", # required, limited to 128-chars
         policy_document: policy_document,
       ] unless policy_document['Statement'].empty?
 

--- a/lib/jets/resource/iam/class_role.rb
+++ b/lib/jets/resource/iam/class_role.rb
@@ -12,9 +12,9 @@ module Jets::Resource::Iam
       "{namespace}_iam_role".underscore
     end
 
-    def role_name
+    def policy_name
       class_namespace = replacements[:namespace].underscore.dasherize
-      "#{Jets.config.project_namespace}-#{class_namespace}-role" # camelized because used as template value
+      "#{Jets.config.project_namespace}-#{class_namespace}-policy" # camelized because used as template value
     end
 
     def replacements

--- a/lib/jets/resource/iam/function_role.rb
+++ b/lib/jets/resource/iam/function_role.rb
@@ -12,9 +12,9 @@ module Jets::Resource::Iam
       "{namespace}_iam_role".underscore
     end
 
-    def role_name
+    def policy_name
       funcion_namespace = replacements[:namespace].underscore.dasherize
-      "#{Jets.config.project_namespace}-#{funcion_namespace}-role" # camelized because used as template value
+      "#{Jets.config.project_namespace}-#{funcion_namespace}-policy" # camelized because used as template value
     end
 
     def replacements

--- a/lib/jets/resource/lambda/function.rb
+++ b/lib/jets/resource/lambda/function.rb
@@ -127,6 +127,7 @@ module Jets::Resource::Lambda
       managed = {
         handler: handler,
         runtime: runtime,
+        description: description,
       }
       managed[:function_name] = function_name if function_name
       layers = get_layers(runtime)
@@ -201,6 +202,15 @@ module Jets::Resource::Lambda
       # CloudFormation will managed the the function name in this case.
       # A pretty function name won't be generated but the deploy will be successful.
       function_name.size > MAX_FUNCTION_NAME_SIZE ? nil : function_name
+    end
+
+    def description
+      # Example values:
+      #   @app_class: Admin/PagesController
+      #   @task.meth: index
+      # Returns:
+      #   Admin/PagesController#index
+      "#{@app_class}##{@task.meth}"
     end
   end
 end

--- a/spec/lib/jets/resource/api_gateway/rest_api/routes/change/base_spec.rb
+++ b/spec/lib/jets/resource/api_gateway/rest_api/routes/change/base_spec.rb
@@ -2,6 +2,10 @@ describe Jets::Resource::ApiGateway::RestApi::Routes::Change::Base do
   let(:base) do
     Jets::Resource::ApiGateway::RestApi::Routes::Change::Base.new
   end
+  let(:lambda) do
+    lambda = double(:lambda).as_null_object
+    lambda
+  end
 
   it "recreate_path" do
     path = base.recreate_path('/posts/{id}/edit')
@@ -10,6 +14,7 @@ describe Jets::Resource::ApiGateway::RestApi::Routes::Change::Base do
 
   it "recreate_to" do
     method_uri = "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:112233445566:function:demo-test-posts_controller-show/invocations"
+    allow(base).to receive(:lambda_function_description).and_return("PostsController#show")
     to = base.recreate_to(method_uri)
     expect(to).to eq 'posts#show'
   end

--- a/spec/lib/jets/resource/api_gateway/rest_api/routes/change/base_spec.rb
+++ b/spec/lib/jets/resource/api_gateway/rest_api/routes/change/base_spec.rb
@@ -12,8 +12,14 @@ describe Jets::Resource::ApiGateway::RestApi::Routes::Change::Base do
     expect(path).to eq 'posts/:id/edit'
   end
 
-  it "recreate_to" do
+  it "recreate_to controller_action_from_string" do
     method_uri = "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:112233445566:function:demo-test-posts_controller-show/invocations"
+    to = base.recreate_to(method_uri)
+    expect(to).to eq 'posts#show'
+  end
+
+  it "recreate_to controller_action_from_api" do
+    method_uri = "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:112233445566:function:demo-test-posts_XX/invocations"
     allow(base).to receive(:lambda_function_description).and_return("PostsController#show")
     to = base.recreate_to(method_uri)
     expect(to).to eq 'posts#show'

--- a/spec/lib/jets/resource/lambda/function_spec.rb
+++ b/spec/lib/jets/resource/lambda/function_spec.rb
@@ -24,6 +24,7 @@ describe Jets::Resource::Lambda::Function do
       properties = resource.properties
       # puts YAML.dump(properties) # uncomment to debug
       expect(properties["FunctionName"]).to eq "demo-test-posts_controller-index"
+      expect(properties["Description"]).to eq "PostsController#index"
       expect(properties["Handler"]).to eq "handlers/controllers/posts_controller.index"
       expect(properties["Code"]["S3Key"]).to include("jets/code")
     end
@@ -39,6 +40,7 @@ describe Jets::Resource::Lambda::Function do
       properties = resource.properties
       # puts YAML.dump(properties) # uncomment to debug
       expect(properties["FunctionName"]).to eq "demo-test-hard_job-dig"
+      expect(properties["Description"]).to eq "HardJob#dig"
       expect(properties["Handler"]).to eq "handlers/jobs/hard_job.dig"
       expect(properties["Code"]["S3Key"]).to include("jets/code")
     end
@@ -46,15 +48,16 @@ describe Jets::Resource::Lambda::Function do
 
   context("function with _function") do
     let(:task) do
-      Jets::Lambda::Task.new("SimpleFunction", :handler)
+      Jets::Lambda::Task.new("SimpleFunction", :lambda_handler)
     end
 
     it "contains info for CloudFormation Job Function Resources" do
-      expect(resource.logical_id).to eq "HandlerLambdaFunction"
+      expect(resource.logical_id).to eq "LambdaHandlerLambdaFunction"
       properties = resource.properties
       # puts YAML.dump(properties) # uncomment to debug
-      expect(properties["FunctionName"]).to eq "demo-test-simple_function-handler"
-      expect(properties["Handler"]).to eq "handlers/functions/simple_function.handler"
+      expect(properties["FunctionName"]).to eq "demo-test-simple_function-lambda_handler"
+      expect(properties["Description"]).to eq "SimpleFunction#lambda_handler"
+      expect(properties["Handler"]).to eq "handlers/functions/simple_function.lambda_handler"
       expect(properties["Code"]["S3Key"]).to include("jets/code")
     end
   end


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

Remove pretty IAM role names. Do not assign pretty role_name because long controller names might hit the 64-char.  limit. Also, IAM roles are global, so assigning role names prevents cross region deploys.

## Context

<!--
Is this related to any GitHub issue(s)?
-->

#160 


## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
