### PR TITLE
use encoding from content-type for mega request

### DIFF
--- a/lib/jets/application.rb
+++ b/lib/jets/application.rb
@@ -90,6 +90,12 @@ class Jets::Application
     config.lambda = ActiveSupport::OrderedOptions.new
     config.lambda.layers = []
 
+    # Only used for Jets Afterburner, Mega Mode currently. This is a fallback default
+    # encoding.  Usually, the Rails response will return a content-type header and
+    # the encoding in there is used when possible. Example Content-Type header:
+    #   Content-Type    text/html; charset=utf-8
+    config.encoding = "utf-8"
+
     config
   end
 

--- a/lib/jets/mega/request.rb
+++ b/lib/jets/mega/request.rb
@@ -48,11 +48,25 @@ module Jets::Mega
 
       puts_rack_output
 
+      status = response.code.to_i
+      headers = response.each_header.to_h
+      encoding = get_encoding(headers['content-type'])
+      body = response.body.force_encoding(encoding)
       {
-        status: response.code.to_i,
-        headers: response.each_header.to_h,
-        body: response.body,
+        status: status,
+        headers: headers,
+        body: body,
       }
+    end
+
+    def get_encoding(content_type)
+      default = Jets.config.encoding
+      return default unless content_type
+
+      md = content_type.match(/charset=(.+)/)
+      return default unless md
+
+      md[1]
     end
 
     # Grab the rack output from the /tmp/jets-output.log and puts it back in the


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)


<!--
Provide a description of what your pull request changes.
-->


<!--
Is this related to any GitHub issue(s)?
-->

https://community.rubyonjets.com/t/error-errortype-function-encoding-undefinedconversionerror-on-marshall-response/68/5


<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->