### PR TITLE
controller authorization_type declaration

### DIFF
--- a/docs/_docs/routing-authorization.md
+++ b/docs/_docs/routing-authorization.md
@@ -4,26 +4,7 @@ title: Authorization
 
 ## Authorization
 
-By default, each route does not require any authorization. You can enable authorization application-wide with `config/application.rb`:
-
-```ruby
-Jets.application.configure do
-  config.api.authorization_type = "AWS_IAM"
-end
-```
-
-This will require a caller to authenticate using IAM before being able to access the endpoint.
-
-You can also enable authorization on a per-route basis with the `authorization_type` option:
-
-```ruby
-Jets.application.routes.draw do
-  get  "posts", to: "posts#index", authorization_type: "AWS_IAM"
-end
-```
-
-
-There are several authorization types available:
+By default, calling API Gateway does not require authorization. You can add authorization to your API with API Gateway authorization types. There are several authorization types available:
 
 * NONE - open access
 * AWS_IAM - use [AWS IAM](https://aws.amazon.com/iam/) permissions
@@ -31,6 +12,42 @@ There are several authorization types available:
 * COGNITO_USER_POOLS - [Cognito](https://aws.amazon.com/cognito/) User Pool
 
 The complete list of authorization types is available in the [AWS API Gateway docs](https://docs.aws.amazon.com/apigateway/api-reference/resource/method/#authorizationType).
+
+You can also make use of [Before Filters]({% link _docs/action-filters.md %}) to build your own custom authorization system instead of using API Gateway Authorization types.
+
+### Application Wide
+
+You can enable authorization application-wide with `config/application.rb`:
+
+```ruby
+Jets.application.configure do
+  config.api.authorization_type = :aws_iam
+end
+```
+
+This will require a caller to authenticate using IAM before being able to access the endpoint.
+
+### Controller Wide
+
+You can enable controller-wide authorization also.  Example:
+
+```ruby
+class PostsController < ApplicationController
+  authorization_type :aws_iam
+end
+```
+
+All controller actions will be use `AWS_IAM` authorization.
+
+### Route Specific
+
+You can also enable authorization on a per-route basis with the `authorization_type` option:
+
+```ruby
+Jets.application.routes.draw do
+  get  "posts", to: "posts#index", authorization_type: :aws_iam
+end
+```
 
 <a id="prev" class="btn btn-basic" href="{% link _docs/routing-overview.md %}">Back</a>
 <a id="next" class="btn btn-primary" href="{% link _docs/routing-custom-domain.md %}">Next Step</a>

--- a/lib/jets/controller/base.rb
+++ b/lib/jets/controller/base.rb
@@ -90,5 +90,14 @@ class Jets::Controller
         self.internal_controller
       end
     end
+
+    class_attribute :auth_type
+    def self.authorization_type(value=nil)
+      if !value.nil?
+        self.auth_type = value
+      else
+        self.auth_type
+      end
+    end
   end
 end

--- a/lib/jets/resource/api_gateway/method.rb
+++ b/lib/jets/resource/api_gateway/method.rb
@@ -65,8 +65,17 @@ module Jets::Resource::ApiGateway
   private
 
     def authorization_type
-      type = @route.authorization_type || Jets.config.api.authorization_type
-      type.upcase
+      type = @route.authorization_type ||
+             controller_auth_type ||
+             Jets.config.api.authorization_type
+      type.to_s.upcase
+    end
+
+    def controller_auth_type
+      controller_name = @route.to.split('#').first
+      controller = "#{controller_name}_controller".classify.constantize
+      # Already handles inheritance via class_attribute
+      controller.authorization_type
     end
 
     def resource_id

--- a/lib/jets/router.rb
+++ b/lib/jets/router.rb
@@ -84,8 +84,10 @@ module Jets
     end
 
     # root "posts#index"
-    def root(to)
-      @routes << Route.new(path: '', to: to, method: :get, root: true)
+    def root(to, options={})
+      default = {path: '', to: to, method: :get, root: true}
+      options = default.merge(options)
+      @routes << Route.new(options)
     end
 
     # Useful for creating API Gateway Resources


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
This is a 🧐 documentation change.

<!--
Before you submit this pull request, make sure to have a look at the following checklist. If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

Allows us to specify the authorization_type at the controller level. Example:

```ruby
class PostsController < ApplicationController
  authorization_type :aws_iam
end

## Context

<!--
Is this related to any GitHub issue(s)?
-->

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
