### PR TITLE
Fix two routes errors (breaking paths and change detection)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project *loosely tries* to adhere to [Semantic Versioning](http://semver.org/), even before v1.0.
 
+## [UNRELEASED]
+- Fix invalid route changes reading routine when route contains more than one variable in path
+
 ## [1.6.5]
 - #173 application/xml content-type on render xml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project *loosely tries* to adhere to [Semantic Versioning](http://semver.or
 
 ## [UNRELEASED]
 - Fix invalid route changes reading routine when route contains more than one variable in path
+- Fix invalid lambda function names for controllers in deep namespaces like A::B::MyController
 
 ## [1.6.5]
 - #173 application/xml content-type on render xml

--- a/lib/jets/resource/api_gateway/rest_api/routes/change/base.rb
+++ b/lib/jets/resource/api_gateway/rest_api/routes/change/base.rb
@@ -43,8 +43,8 @@ class Jets::Resource::ApiGateway::RestApi::Routes::Change
 
     def recreate_path(path)
       path = path.gsub(%r{^/},'')
-      path = path.sub(/{(.*)\+}/, '*\1')
-      path.sub(/{(.*)}/, ':\1')
+      path = path.gsub(/{([^}]*)\+}/, '*\1')
+      path.gsub(/{([^}]*)}/, ':\1')
     end
 
     def to(resource_id, http_method)

--- a/lib/jets/resource/lambda/function.rb
+++ b/lib/jets/resource/lambda/function.rb
@@ -196,7 +196,7 @@ module Jets::Resource::Lambda
       #   method: admin/pages_controller
       #   method: admin-pages_controller-index
       method = @app_class.underscore
-      method = method.sub('/','-').gsub(/[^0-9a-z\-_]/i, '') + "-#{@task.meth}"
+      method = method.gsub('/','-').gsub(/[^0-9a-z\-_]/i, '') + "-#{@task.meth}"
       function_name = "#{Jets.config.project_namespace}-#{method}"
       # Returns nil if function name is too long.
       # CloudFormation will managed the the function name in this case.

--- a/spec/lib/jets/resource/api_gateway/rest_api/routes/change/base_spec.rb
+++ b/spec/lib/jets/resource/api_gateway/rest_api/routes/change/base_spec.rb
@@ -6,6 +6,9 @@ describe Jets::Resource::ApiGateway::RestApi::Routes::Change::Base do
   it "recreate_path" do
     path = base.recreate_path('/posts/{id}/edit')
     expect(path).to eq 'posts/:id/edit'
+
+    path = base.recreate_path('/posts/{id}/edit/{another_id}')
+    expect(path).to eq 'posts/:id/edit/:another_id'
   end
 
   it "recreate_to controller_action_from_string" do

--- a/spec/lib/jets/resource/lambda/function_spec.rb
+++ b/spec/lib/jets/resource/lambda/function_spec.rb
@@ -30,6 +30,30 @@ describe Jets::Resource::Lambda::Function do
     end
   end
 
+  context "deeply namespaced controller" do
+    module Deep
+      module Namespace
+        class TestController < Jets::Controller::Base
+          def index; end
+        end
+      end
+    end
+
+    let(:task) do
+      Deep::Namespace::TestController.all_public_tasks[:index]
+    end
+
+    it "contains info for CloudFormation Controller Function Resources" do
+      expect(resource.logical_id).to eq "IndexLambdaFunction"
+      properties = resource.properties
+      # puts YAML.dump(properties) # uncomment to debug
+      expect(properties["FunctionName"]).to eq "demo-test-deep-namespace-test_controller-index"
+      expect(properties["Description"]).to eq "Deep::Namespace::TestController#index"
+      expect(properties["Handler"]).to eq "handlers/controllers/deep/namespace/test_controller.index"
+      expect(properties["Code"]["S3Key"]).to include("jets/code")
+    end
+  end
+
   context("job") do
     let(:task) do
       HardJob.all_public_tasks[:dig]


### PR DESCRIPTION
Fixed two errors:

1. When route contains more than one variable in path, like:
`/posts/{id}/edit/{another_id}`

2. Invalid lambda function names for controllers in deep namespaces like:
`A::B::MyController`

- I read the contributing document at https://rubyonjets.com/docs/contributing/

This is a 🐞 bug fix.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)
