### PR TITLE
spec_helpers: get request now accepts query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project *loosely tries* to adhere to [Semantic Versioning](http://semver.org/), even before v1.0.
 
+## [UNRELEASED]
+- spec\_helpers: `get` request now converts dangling params to query params. `query` keyword can be used to do the same thing explicitly.
+
 ## [1.7.1]
 - fix Turbines with no initializer blocks
 

--- a/lib/jets/spec_helpers.rb
+++ b/lib/jets/spec_helpers.rb
@@ -32,6 +32,11 @@ module Jets
       request.headers.deep_merge!(params.delete(:headers) || {})
 
       request.params.body_params = params.delete(:params) || params || {}
+
+      request.params.query_params = params.delete(:query)
+      request.params.query_params ||= params if request.method == :get
+      request.params.query_params ||= {}
+
       request.params.path_params = params
 
       @response = request.dispatch!

--- a/lib/jets/spec_helpers/params.rb
+++ b/lib/jets/spec_helpers/params.rb
@@ -1,9 +1,9 @@
 module Jets
   module SpecHelpers
     class Params
-      attr_accessor :path_params, :body_params
-      def initialize(path_params={}, body_params={})
-        @path_params, @body_params = path_params, body_params
+      attr_accessor :path_params, :body_params, :query_params
+      def initialize(path_params={}, body_params={}, query_params={})
+        @path_params, @body_params, @query_params = path_params, body_params, query_params
       end
     end
   end

--- a/lib/jets/spec_helpers/request.rb
+++ b/lib/jets/spec_helpers/request.rb
@@ -41,6 +41,12 @@ module Jets
           json['isBase64Encoded'] = true
         end
 
+        params.query_params.to_a.each do |e|
+          key, value = e
+          json['queryStringParameters'] ||= {}
+          json['queryStringParameters'][key.to_s] = value.to_s
+        end
+
         json
       end
 

--- a/spec/lib/jets/spec_helpers_spec.rb
+++ b/spec/lib/jets/spec_helpers_spec.rb
@@ -13,7 +13,7 @@ class SimpleController < Jets::Controller::Base
     if params[:id] == '404'
       render json: {}, status: :not_found
     else
-      render json: { id: params[:id] }
+      render json: { id: params[:id], filter: params[:filter] }
     end
   end
 
@@ -54,6 +54,18 @@ describe Jets::SpecHelpers do
       get '/spec_helper_test/:id', id: 123
       expect(response.status).to eq 200
       expect(JSON.parse(response.body)['id']).to eq '123'
+    end
+
+    it "gets 200 with query params" do
+      get '/spec_helper_test/:id', id: 123, query: { filter: 'abc' }
+      expect(response.status).to eq 200
+      expect(JSON.parse(response.body)['filter']).to eq 'abc'
+    end
+
+    it "gets 200 with query params no query keyword" do
+      get '/spec_helper_test/:id', id: 123, filter: 'abc'
+      expect(response.status).to eq 200
+      expect(JSON.parse(response.body)['filter']).to eq 'abc'
     end
 
     it "gets 404 with id" do


### PR DESCRIPTION
<!-- This is a 🙋‍♂️ feature or enhancement. -->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

Running `get "/path", query: { a: 1 }` now allows to execute an endpoint like `GET /path?a=1`.