### PR TITLE
fix jets eager load, order by path length

### DIFF
--- a/lib/jets/booter.rb
+++ b/lib/jets/booter.rb
@@ -150,7 +150,12 @@ class Jets::Booter
     # Eager load jet's lib and classes
     def eager_load_jets
       lib_jets = File.expand_path(".", File.dirname(__FILE__))
-      Dir.glob("#{lib_jets}/**/*.rb").select do |path|
+
+      # Sort by path length because systems return Dir.glob in different order
+      # Sometimes it returns longer paths first which messed up eager loading.
+      paths = Dir.glob("#{lib_jets}/**/*.rb")
+      paths = paths.sort_by { |p| p.size }
+      paths.select do |path|
         next if !File.file?(path)
         next if skip_eager_load_paths?(path)
 


### PR DESCRIPTION
* seems like on some systems Dir.glob returns paths in a different order

<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

#193

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
