### PR TITLE
Fix for error message on booting with missing database environment

### DIFF
--- a/lib/jets/booter.rb
+++ b/lib/jets/booter.rb
@@ -112,7 +112,7 @@ class Jets::Booter
       ActiveRecord::Tasks::DatabaseTasks.database_configuration = db_configs
 
       current_config = db_configs[Jets.env]
-      if current_config.empty?
+      if current_config.blank?
         abort("ERROR: config/database.yml exists but no environment section configured for #{Jets.env}")
       end
       # Using ActiveRecord rake tasks outside of Rails, so we need to set up the


### PR DESCRIPTION
This is a 🐞 bug fix.

## Summary

Changes `empty?` to `blank?` on the boot check for a configured database setup, to account for `nil`.

## Context

Fixes tongueroo/jets#203

## Version Changes

1.8.7
