### PR TITLE
Use ActiveSupport::Rescuable in base Jets controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ demo*
 /html
 spec/fixtures/apps/franky/dynamodb/migrate
 Gemfile.lock 
+.byebug_history

--- a/docs/_docs/action-filters.md
+++ b/docs/_docs/action-filters.md
@@ -36,5 +36,5 @@ end
 ```
 
 <a id="prev" class="btn btn-basic" href="{% link _docs/upload-binary-files.md %}">Back</a>
-<a id="next" class="btn btn-primary" href="{% link _docs/minimal-deploy-iam.md %}">Next Step</a>
+<a id="next" class="btn btn-primary" href="{% link _docs/rescue-from.md %}">Next Step</a>
 <p class="keyboard-tip">Pro tip: Use the <- and -> arrow keys to move back and forward.</p>

--- a/docs/_docs/minimal-deploy-iam.md
+++ b/docs/_docs/minimal-deploy-iam.md
@@ -75,6 +75,6 @@ This page refers to your **user** IAM policy used when running `jets deploy`. Th
 * [IAM Policies]({% link _docs/iam-policies.md %})
 * [Managed IAM Policies]({% link _docs/managed-iam-policies.md %})
 
-<a id="prev" class="btn btn-basic" href="{% link _docs/action-filters.md %}">Back</a>
+<a id="prev" class="btn btn-basic" href="{% link _docs/rescue-from.md %}">Back</a>
 <a id="next" class="btn btn-primary" href="{% link _docs/custom-inflections.md %}">Next Step</a>
 <p class="keyboard-tip">Pro tip: Use the <- and -> arrow keys to move back and forward.</p>

--- a/docs/_docs/rescue-from.md
+++ b/docs/_docs/rescue-from.md
@@ -1,0 +1,37 @@
+---
+title: Error Handling
+---
+
+Jets provides some error handling capabilities in controllers that can rescue errors that occur during the callbacks or action. This is done with the `rescue_from` method.
+
+## Example rescue_from
+
+```ruby
+class PostsController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound do |exception|
+    render json: { message: "We could not find your post." }, status: 404
+  end
+
+  # ...
+end
+```
+
+## Example using `with` association
+
+```ruby
+class PostsController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :missing_post
+  
+  # ...
+  
+private
+  def missing_post
+    render json: { message: "We could not find your post." }, status: 404
+  end
+end
+```
+
+<a id="prev" class="btn btn-basic" href="{% link _docs/action-filters.md %}">Back</a>
+<a id="next" class="btn btn-primary" href="{% link _docs/minimal-deploy-iam.md %}">Next Step</a>
+<p class="keyboard-tip">Pro tip: Use the <- and -> arrow keys to move back and forward.</p>
+

--- a/docs/_includes/subnav.html
+++ b/docs/_includes/subnav.html
@@ -93,6 +93,7 @@
                 <li><a href="{% link _docs/assets-serving.md %}">Assets Serving</a></li>
                 <li><a href="{% link _docs/upload-binary-files.md %}">Upload Binary Files</a></li>
                 <li><a href="{% link _docs/action-filters.md %}">Action Filters</a></li>
+                <li><a href="{% link _docs/rescue-from.md %}">Error Handling</a></li>
                 <li><a href="{% link _docs/minimal-deploy-iam.md %}">Minimal Deploy IAM</a></li>
                 <li><a href="{% link _docs/custom-inflections.md %}">Custom Inflections</a></li>
                 <li><a href="{% link _docs/config-rules.md %}">Config Rules</a></li>

--- a/lib/jets/controller.rb
+++ b/lib/jets/controller.rb
@@ -13,4 +13,5 @@ class Jets::Controller
   autoload :Rendering, "jets/controller/rendering"
   autoload :Request, "jets/controller/request"
   autoload :Response, "jets/controller/response"
+  autoload :Rescue, "jets/controller/rescue"
 end

--- a/lib/jets/controller.rb
+++ b/lib/jets/controller.rb
@@ -13,5 +13,4 @@ class Jets::Controller
   autoload :Rendering, "jets/controller/rendering"
   autoload :Request, "jets/controller/request"
   autoload :Response, "jets/controller/response"
-  autoload :Rescue, "jets/controller/rescue"
 end

--- a/lib/jets/controller/base.rb
+++ b/lib/jets/controller/base.rb
@@ -4,6 +4,7 @@ require "rack/utils" # Rack::Utils.parse_nested_query
 # Controller public methods get turned into Lambda functions.
 class Jets::Controller
   class Base < Jets::Lambda::Functions
+    include ActiveSupport::Rescuable
     include Callbacks
     include Cookies
     include Layout

--- a/lib/jets/controller/base.rb
+++ b/lib/jets/controller/base.rb
@@ -4,12 +4,12 @@ require "rack/utils" # Rack::Utils.parse_nested_query
 # Controller public methods get turned into Lambda functions.
 class Jets::Controller
   class Base < Jets::Lambda::Functions
-    include ActiveSupport::Rescuable
     include Callbacks
     include Cookies
     include Layout
     include Params
     include Rendering
+    include ActiveSupport::Rescuable
 
     delegate :headers, to: :request
     delegate :set_header, to: :response
@@ -38,19 +38,24 @@ class Jets::Controller
       t1 = Time.now
       log_info_start
 
-      if run_before_actions(break_if: -> { @rendered })
-        send(@meth)
+      begin
+        if run_before_actions(break_if: -> { @rendered })
+          send(@meth)
+          action_completed = true
+        else
+          Jets.logger.info "Filter chain halted as #{@last_callback_name} rendered or redirected"
+        end
+        
         triplet = ensure_render
-        run_after_actions
-      else
-        Jets.logger.info "Filter chain halted as #{@last_callback_name} rendered or redirected"
+        run_after_actions if action_completed
+      rescue Exception => exception
+        rescue_with_handler(exception) || raise
         triplet = ensure_render
       end
 
       took = Time.now - t1
       status = triplet[0]
       Jets.logger.info "Completed Status Code #{status} in #{took}s"
-
       triplet # status, headers, body
     end
 

--- a/lib/jets/controller/callbacks.rb
+++ b/lib/jets/controller/callbacks.rb
@@ -4,10 +4,8 @@ class Jets::Controller
   module Callbacks
     extend ActiveSupport::Concern
     included do
-      class_attribute :before_actions
-      self.before_actions = []
-      class_attribute :after_actions
-      self.after_actions = []
+      class_attribute :before_actions, default: []
+      class_attribute :after_actions, default: []
 
       class << self
         def before_action(meth, options={})

--- a/spec/lib/jets/controller/base_spec.rb
+++ b/spec/lib/jets/controller/base_spec.rb
@@ -10,6 +10,12 @@ describe Jets::Controller::Base do
   let(:context) { nil }
   let(:meth) { "index" }
 
+  context "class methods" do
+    it "responds to rescue_from method" do
+      expect(Jets::Controller::Base.respond_to?(:rescue_from)).to be true
+    end
+  end
+
   context "general" do
     let(:event) { {} }
     it "lambda_functions returns public user-defined methods" do

--- a/spec/lib/jets/controller/rescuable_spec.rb
+++ b/spec/lib/jets/controller/rescuable_spec.rb
@@ -1,0 +1,29 @@
+class RescuableController < Jets::Controller::Base
+  rescue_from StandardError, with: :error_handler
+
+  def index
+    raise StandardError
+  end
+
+  private
+
+  def error_handler
+    render json: { error: "there was an error" }, status: 500
+  end
+end
+
+describe Jets::Controller::Base do
+  context RescuableController do
+    let(:controller) { RescuableController.new({}, nil, :index) }
+
+    it "rescue_handlers includes error_handler only" do
+      expect(controller.class.rescue_handlers).to eq [["StandardError", :error_handler]]
+    end
+
+    it "rescues the error raised in index" do
+      response = controller.dispatch!
+      expect(response[0]).to eq '500'
+      expect(response[2].read).to eq({error: "there was an error"}.to_json)
+    end
+  end
+end


### PR DESCRIPTION
This is a 🙋‍♂️ feature or enhancement.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Provides functionality to allow Jets controllers to rescue from defined errors with specified error handlers, similar to Rails `rescue_from`.

## Context

Provides functionality requested in #207.

## Version Changes

I would recommend release in a new `MINOR` release.
