### PR TITLE
fix s3 event function for long bucket names

### DIFF
--- a/lib/jets/stack/main/extensions/lambda.rb
+++ b/lib/jets/stack/main/extensions/lambda.rb
@@ -38,7 +38,7 @@ module Jets::Stack::Main::Dsl
       }
 
       function_name = "#{Jets.config.project_namespace}-#{class_namespace}-#{meth}"
-      function_name.size > MAX_FUNCTION_NAME_SIZE ? nil : function_name
+      function_name = function_name.size > MAX_FUNCTION_NAME_SIZE ? nil : function_name
       defaults[:function_name] = function_name if function_name
 
       props = defaults.merge(props)


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

Fix bug that prevents s3 event from working with really long bucket names.

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
