### PR TITLE
Rename lambda

### DIFF
--- a/lib/jets/aws_services.rb
+++ b/lib/jets/aws_services.rb
@@ -32,10 +32,10 @@ module Jets::AwsServices
   end
   global_memoize :dynamodb
 
-  def lambda
+  def aws_lambda
     Aws::Lambda::Client.new
   end
-  global_memoize :lambda
+  global_memoize :aws_lambda
 
   def logs
     Aws::CloudWatchLogs::Client.new

--- a/lib/jets/commands/call.rb
+++ b/lib/jets/commands/call.rb
@@ -65,7 +65,7 @@ class Jets::Commands::Call
       qualifier: @qualifier, # "1",
     }
     begin
-      resp = lambda.invoke(options)
+      resp = aws_lambda.invoke(options)
     rescue Aws::Lambda::Errors::ResourceNotFoundException
       puts "The function #{function_name} was not found.  Maybe check the spelling or the AWS_PROFILE?".color(:red)
       return

--- a/spec/lib/jets/commands/call_spec.rb
+++ b/spec/lib/jets/commands/call_spec.rb
@@ -1,7 +1,7 @@
 describe Jets::Commands::Call do
   let(:call) do
     call = Jets::Commands::Call.new(provided_function_name, event, mute: true)
-    allow(call).to receive(:lambda).and_return(null)
+    allow(call).to receive(:aws_lambda).and_return(null)
     call
   end
   let(:null) { double(:null).as_null_object }


### PR DESCRIPTION
This is a 🐞 bug fix.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this) (

## Summary

Rename `Jets::AwsServices#lambda` to `Jets::AwsServices#aws_lambda`.

## Context

The method `Jets::AwsServices#lambda` collides with `Kernel#lamba`.

https://community.rubyonjets.com/t/collision-of-lambda-method/132

