### PR TITLE
Interpolate values from SSM Parameter Store when initializing Dotenv

### DIFF
--- a/docs/_docs/env-files.md
+++ b/docs/_docs/env-files.md
@@ -35,3 +35,12 @@ To use the remote version within the `jets console`, you can use the `JETS_ENV_R
     JETS_ENV=development JETS_ENV_REMOTE=1 jets console
 
 {% include prev_next.md %}
+
+## Referencing the AWS Systems Manager (SSM) Parameter Store
+
+A common practice when using AWS is to store configuration and credentials in the SSM parameter store. You can reference SSM Parameters as the source of your variables with the `ssm:param-name` syntax. `param-name` can be either a relative or absolute path. Absolute paths are prefixed with a leading `/`. Relative parameters will automatically be prefixed with the conventional `/<app-name>/<jets-env>/`. For example:
+
+    RELATIVE_DATABASE_URL=ssm:database-url # references /<app-name>/<jets-env>/database-url
+    ABSOLUTE_DATABASE_URL=ssm:/path/to/database-url # references /path/to/database-url
+
+The SSM parameters are fetched and interpolated into your environment at build time so make sure to re-deploy your app after making changes to your SSM parameters to ensure they are picked up correctly.

--- a/jets.gemspec
+++ b/jets.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws-sdk-s3"
   spec.add_dependency "aws-sdk-sns"
   spec.add_dependency "aws-sdk-sqs"
+  spec.add_dependency "aws-sdk-ssm"
   spec.add_dependency "cfnresponse"
   spec.add_dependency "dotenv"
   spec.add_dependency "gems" # jets-gems dependency

--- a/lib/jets/dotenv.rb
+++ b/lib/jets/dotenv.rb
@@ -2,7 +2,7 @@ require 'dotenv'
 require 'aws-sdk-ssm'
 
 class Jets::Dotenv
-  SSM_VARIABLE_REGEXP = /\$\{ssm:([a-zA-Z0-9_.\-\/]+)}/
+  SSM_VARIABLE_REGEXP = /^ssm:(.*)/
 
   def self.load!(remote=false)
     new(remote).load!
@@ -45,10 +45,11 @@ class Jets::Dotenv
 
   def interpolate_ssm_variables(variables)
     interpolated_variables = variables.map do |key, value|
-      interpolated_value = value.gsub(SSM_VARIABLE_REGEXP) do |match|
-        fetch_ssm_value($1)
+      if value[SSM_VARIABLE_REGEXP]
+        value = fetch_ssm_value($1)
       end
-      [key, interpolated_value]
+
+      [key, value]
     end
 
     interpolated_variables.each do |key, value|

--- a/spec/lib/jets/dotenv_spec.rb
+++ b/spec/lib/jets/dotenv_spec.rb
@@ -1,0 +1,63 @@
+describe Jets::Dotenv do
+  describe "#load!" do
+    it "replaces ${ssm:<relative-path>} with SSM parameters prefixed with /<app-name>/<jets-env>/" do
+      expect(::Dotenv).to receive(:load).and_return(
+        "AUTENTICATED_URL" => "https://${ssm:username}:${ssm:password}@host.com",
+      )
+
+      username_response_double = double(
+        Aws::SSM::Types::GetParameterResult,
+        parameter: Aws::SSM::Types::Parameter.new(value: "my-user"),
+      )
+      expect_any_instance_of(Aws::SSM::Client).to receive(:get_parameter)
+        .with(name: "/demo/test/username", with_decryption: true)
+        .and_return(username_response_double)
+
+      password_response_double = double(
+        Aws::SSM::Types::GetParameterResult,
+        parameter: Aws::SSM::Types::Parameter.new(value: "my-password"),
+      )
+      expect_any_instance_of(Aws::SSM::Client).to receive(:get_parameter)
+        .with(name: "/demo/test/password", with_decryption: true)
+        .and_return(password_response_double)
+
+      env = Jets::Dotenv.new.load!
+
+      expect(env.fetch("AUTENTICATED_URL")).to eq "https://my-user:my-password@host.com"
+      expect(ENV.fetch("AUTENTICATED_URL")).to eq "https://my-user:my-password@host.com"
+    end
+
+    it "replaces ${ssm:/<absolute-path>} with SSM parameters from the provided path" do
+      expect(::Dotenv).to receive(:load).and_return(
+        "ABSOLUTE_VARIABLE" => "${ssm:/absolute/path}",
+      )
+
+      absolute_response_double = double(
+        Aws::SSM::Types::GetParameterResult,
+        parameter: Aws::SSM::Types::Parameter.new(value: "my-absolute-value"),
+      )
+      expect_any_instance_of(Aws::SSM::Client).to receive(:get_parameter)
+        .with(name: "/absolute/path", with_decryption: true)
+        .and_return(absolute_response_double)
+
+
+      env = Jets::Dotenv.new.load!
+
+      expect(env.fetch("ABSOLUTE_VARIABLE")).to eq "my-absolute-value"
+      expect(ENV.fetch("ABSOLUTE_VARIABLE")).to eq "my-absolute-value"
+    end
+
+    it "aborts the process with a helpful error if an SSM parameter is not found at AWS" do
+      expect(::Dotenv).to receive(:load).and_return(
+        "ABSOLUTE_VARIABLE" => "${ssm:/absolute/path}",
+      )
+
+      expect_any_instance_of(Aws::SSM::Client).to receive(:get_parameter)
+        .and_raise(Aws::SSM::Errors::ParameterNotFound.new(Seahorse::Client::RequestContext.new, ""))
+
+      expect { Jets::Dotenv.new.load! }
+        .to raise_error(SystemExit)
+        .and output(/No parameter matching \/absolute\/path found/).to_stderr
+    end
+  end
+end


### PR DESCRIPTION
This is a 🙋‍♂️ feature or enhancement.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Mimics the same behaviour and interpolation syntax found in `serverless`, ie: `${smm:<parameter-name>}` (https://serverless.com/framework/docs/providers/aws/guide/variables/#reference-variables-using-the-ssm-parameter-store). However it will default to decrypting secure parameters and does not attempt to add any weird syntax for toggling the functionality. It seems to me that 99.9% of cases will want decrypted values. If anyone has any real world use cases for wanting encrypted values instead we could expand on the syntax with a disabling feature later.

We also introduce conventions for relative vs absolute paths. For example:
`${ssm:relative-variable}` will be expanded to `${ssm:/<app-name>/<jets-environment>/relative-variable}` while an absolute path (prefixed with /) will not be expanded.

If Jets fails to find a given parameter at AWS it will immediately abort the process with a helpful error message.

Note that it is mandatory to wrap `.env` file variables in single quotes to avoid losing the dollar sign  since dollar signs are also the conventional way of referencing other variables in bash (see https://stackoverflow.com/a/37876900 for explanation). For example:

```bash
# Good:
MY_SSM_VARIABLE='${ssm:parameter-name}'

# Bad:
MY_SSM_VARIABLE=${ssm:parameter-name}
MY_SSM_VARIABLE="${ssm:parameter-name}"
```

I will be happy add documentation for this feature after we have 100% settled on the general behaviour and implementation details.

## Context

This work was initiated after discussing SSM parameters in Jets at https://community.rubyonjets.com/t/thoughts-on-ssm-parameter-store-for-configuration

## Version Changes

I would go for a minor version bump. Note that we're potentially breaking backwards compatibility if someone is already using this syntax in their own `.env` files but this seems highly unlikely.