### PR TITLE
Better API mode controller generator

### DIFF
--- a/lib/jets/generator.rb
+++ b/lib/jets/generator.rb
@@ -24,14 +24,18 @@ class Jets::Generator
     g = Rails::Configuration::Generators.new
     g.orm             :active_record, migration: true, timestamps: true
     # TODO: support g.orm :dynamodb
-    g.template_engine :erb
     g.test_framework  false #:test_unit, fixture: false
     # g.test_framework :rspec # need to
     # TODO: load rspec configuration to use rspec
     g.stylesheets     false
     g.javascripts     false
     g.assets          false
-    g.api             Jets.config.mode == 'api'
+    if Jets.config.mode == 'api'
+      g.api_only = true
+      g.template_engine nil
+    else
+      g.template_engine :erb
+    end
     g.resource_route  true
     g.templates.unshift(template_paths)
     g


### PR DESCRIPTION
This is a 🐞 bug fix.

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

I've not added tests as the tests around generators are quite bare, likely because it relies a lot on Rails generators. I would be happy to help write tests for the generators as part of a bigger piece of work on this.

## Summary

When generating a controller for an API mode application, Jets currently generates helpers and views. Rails wouldn't generate those in API mode.

This fixes the generator config for API mode.