### PR TITLE
Fix routing link in considerations-api-gateway doc

### DIFF
--- a/docs/_docs/considerations-api-gateway.md
+++ b/docs/_docs/considerations-api-gateway.md
@@ -3,7 +3,7 @@ title: API Gateway Routes
 nav_order: 77
 ---
 
-Jets translates `config/routes.rb` definitions to API Gateway Resources: [Routing Overview](http://rubyonjets.com/docs/routing-overview/). Essentially, API Gateway is the routing layer of a Jets application.  From the [AWS API Gateway](https://aws.amazon.com/api-gateway/) product page:
+Jets translates `config/routes.rb` definitions to API Gateway Resources: [Routing Overview](http://rubyonjets.com/docs/routing/). Essentially, API Gateway is the routing layer of a Jets application.  From the [AWS API Gateway](https://aws.amazon.com/api-gateway/) product page:
 
 >  You can create REST and WebSocket APIs that act as a “front door” for applications to access data, business logic, or functionality from your backend services, such as workloads running on Amazon Elastic Compute Cloud (Amazon EC2), code running on AWS Lambda, any web application, or real-time communication applications.
 


### PR DESCRIPTION
This is a 🧐 documentation change.

## Summary

The link "Routing Overview" on [API Gateway Routes
](http://rubyonjets.com/docs/considerations-api-gateway/) was broken. I fixed it. 

## Context

PR for https://github.com/tongueroo/jets/issues/236

