### PR TITLE
autoload concerns and allow them to work

### DIFF
--- a/lib/jets/application.rb
+++ b/lib/jets/application.rb
@@ -201,9 +201,18 @@ class Jets::Application
   #   app/models
   #   app/rules
   #   app/shared/resources
+  #
+  # Also include:
+  #   app/models/concerns
+  #   app/controllers/concerns
   def default_autoload_paths
     paths = []
     Dir.glob("#{Jets.root}/app/*").each do |p|
+      p.sub!('./','')
+      paths << p unless exclude_autoload_path?(p)
+    end
+    # Handle concerns folders
+    Dir.glob("#{Jets.root}/app/**/concerns").each do |p|
       p.sub!('./','')
       paths << p unless exclude_autoload_path?(p)
     end

--- a/lib/jets/booter.rb
+++ b/lib/jets/booter.rb
@@ -206,6 +206,7 @@ class Jets::Booter
                       .sub(/\.rb$/,'') # remove .rb
                       .sub(%{^\./},'') # remove ./
                       .sub("#{Jets.root}/",'')
+                      .sub(%r{app\/\w+/concerns/},'')
                       .sub(%r{app/shared/\w+/},'') # remove shared/resources or shared/extensions
                       .sub(%r{app/\w+/},'') # remove app/controllers or app/jobs etc
         class_name = class_name.classify


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fixes autoloading when there are concerns folders.

## Context

> RE: I have imported app/models from an app to our serverless jets application using git submodule. Now my jets command won't work because it has dependency on files inside app/models/concerns directory. I tried adding this code config.extra_autoload_paths = ["#{Jets.root}/app/models/concerns"] in application.rb, but it won't work. Could you guide me?

Think what is happening is that with way concerns are organized it messes up the Jets eager loading. Jets loads your app classes as part of bootup. This adds folders like `app/models/concerns` and `app/controllers/concerns` to the autoload paths and also allows them to work.

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
