### PR TITLE
Set ENV['HOME'] to an absolute path

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ ENV["TEST"] = "1"
 ENV["JETS_ENV"] = "test"
 ENV["JETS_ROOT"] = "./spec/fixtures/apps/franky"
 # Ensures aws api never called. Fixture home folder does not contain ~/.aws/credentails
-ENV['HOME'] = "spec/fixtures/home"
+ENV['HOME'] = File.join(Dir.pwd,'spec/fixtures/home')
 ENV['SECRET_KEY_BASE'] = 'fake'
 
 # require "simplecov"


### PR DESCRIPTION
…arf otherwise

<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [X] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

This is a minor change to use an absolute path for `ENV['HOME']` when running tests. Ruby 2.5.3 throws an exception on some of the File/Path I/O operations if the home directory is a relative path. It caused several specs to fail. 
<!--
Provide a description of what your pull request changes.
-->

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## Version Changes

This change only affects development, so it doesn't need to be released with any particular version. 
<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->