### PR TITLE
fix wait_for_socket on aws lambda, rescue Errno::EAFNOSUPPORT

### DIFF
--- a/lib/jets/rack_server.rb
+++ b/lib/jets/rack_server.rb
@@ -64,7 +64,7 @@ module Jets
       begin
         server = TCPSocket.new('localhost', 9292)
         server.close
-      rescue Errno::ECONNREFUSED
+      rescue Errno::ECONNREFUSED, Errno::EAFNOSUPPORT
         puts "Unable to connect to localhost:9292. Delay for #{delay} and will try to connect again."  if ENV['JETS_DEBUG']
         sleep(delay)
         retries += 1


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

The AWS Ruby Runtime changed so that a TCPSocket.new now throws a `Errno::EAFNOSUPPORT` error when the rack server for afterburner mode is not yet up.  This rescues from that exception also.

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
