### PR TITLE
speed up hot reloading in development

### DIFF
--- a/docs/_docs/shared-resources/functions.md
+++ b/docs/_docs/shared-resources/functions.md
@@ -10,7 +10,7 @@ For some Shared Resources you might need to create Lambda functions themselves. 
 app/shared/resources/custom.rb:
 
 ```ruby
-class Custom
+class Custom < Jets::Stack
   function(:bob)
 end
 ```
@@ -36,7 +36,7 @@ For Shared Resource Functions, you can use Python just as easily.  Here's an exa
 app/shared/resources/custom.rb:
 
 ```ruby
-class Custom
+class Custom < Jets::Stack
   python_function(:kevin)
 end
 ```
@@ -56,7 +56,7 @@ Here's also a node example:
 app/shared/resources/custom.rb:
 
 ```ruby
-class Custom
+class Custom < Jets::Stack
   node_function(:stuart)
 end
 ```
@@ -73,7 +73,7 @@ exports.handler = function(event, context, callback) {
 The methods `ruby_function`, `python_function`, and `node_function` all delegate to the `function` method.  Here's what the general `function` method looks like:
 
 ```ruby
-class Custom
+class Custom < Jets::Stack
   function(:kevin,
     handler: "kevin.lambda_handler",
     runtime: "ruby2.5"
@@ -84,7 +84,7 @@ end
 And the `function` method calls the general Jets::Stack `resource` method.  So the above can also be written like so:
 
 ```ruby
-class Custom
+class Custom < Jets::Stack
   resource(:kevin,
     code: {
       s3_bucket: "!Ref S3Bucket",

--- a/docs/_reference/jets-server.md
+++ b/docs/_reference/jets-server.md
@@ -30,12 +30,10 @@ Start up server binding to host `0.0.0.0`:
 ## Options
 
 ```
-[--port=PORT]              # use PORT
-                           # Default: 8888
-[--host=HOST]              # listen on HOST
-                           # Default: 127.0.0.1
-[--reload], [--no-reload]  # Enables hot-reloading for development
-                           # Default: true
-[--noop], [--no-noop]      
+[--port=PORT]          # use PORT
+                       # Default: 8888
+[--host=HOST]          # listen on HOST
+                       # Default: 127.0.0.1
+[--noop], [--no-noop]  
 ```
 

--- a/jets.gemspec
+++ b/jets.gemspec
@@ -56,6 +56,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "recursive-open-struct"
   spec.add_dependency "text-table"
   spec.add_dependency "thor"
+  spec.add_dependency "zeitwerk"
 
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "bundler"

--- a/lib/jets.rb
+++ b/lib/jets.rb
@@ -10,6 +10,7 @@ require "jets/camelizer"
 require "jets/version"
 require "memoist"
 require "rainbow/ext/string"
+require "zeitwerk"
 
 module Jets
   RUBY_VERSION = "2.5.3"

--- a/lib/jets/application.rb
+++ b/lib/jets/application.rb
@@ -189,9 +189,13 @@ class Jets::Application
 
   def setup_auto_load_paths
     autoload_paths = config.autoload_paths + config.extra_autoload_paths
-    # internal_autoload_paths are last
-    autoload_paths += internal_autoload_paths
-    ActiveSupport::Dependencies.autoload_paths += autoload_paths
+    autoload_paths += internal_autoload_paths # internal_autoload_paths are last
+    autoload_paths.each do |path|
+      next unless File.exist?(path)
+      Jets.loader.push_dir(path)
+    end
+    Jets.loader.enable_reloading if Jets.env.development?
+    Jets.loader.setup
   end
 
   # Essentially folders under app folder will be the default_autoload_paths. Example:
@@ -216,6 +220,10 @@ class Jets::Application
       p.sub!('./','')
       paths << p unless exclude_autoload_path?(p)
     end
+
+    paths << "#{Jets.root}/app/shared/resources"
+    paths << "#{Jets.root}/app/shared/extensions"
+
     paths
   end
 

--- a/lib/jets/commands/main.rb
+++ b/lib/jets/commands/main.rb
@@ -36,12 +36,9 @@ module Jets::Commands
     long_desc Help.text(:server)
     option :port, default: "8888", desc: "use PORT"
     option :host, default: "127.0.0.1", desc: "listen on HOST"
-    option :reload, type: :boolean, default: true, desc: "Enables hot-reloading for development"
     def server
-      # shell out to shotgun for automatic reloading
       o = options
-      server_command = o[:reload] ? "shotgun" : "rackup"
-      command = "bundle exec #{server_command} --port #{o[:port]} --host #{o[:host]}"
+      command = "bundle exec rackup --port #{o[:port]} --host #{o[:host]}"
       puts "=> #{command}".color(:green)
       puts Jets::Booter.message
       Jets::Booter.check_config_ru!

--- a/lib/jets/controller/base.rb
+++ b/lib/jets/controller/base.rb
@@ -35,6 +35,8 @@ class Jets::Controller
     end
 
     def dispatch!
+      Jets.loader.reload if Jets.env.development?
+
       t1 = Time.now
       log_info_start
 
@@ -45,7 +47,7 @@ class Jets::Controller
         else
           Jets.logger.info "Filter chain halted as #{@last_callback_name} rendered or redirected"
         end
-        
+
         triplet = ensure_render
         run_after_actions if action_completed
       rescue Exception => exception

--- a/lib/jets/core.rb
+++ b/lib/jets/core.rb
@@ -25,6 +25,11 @@ module Jets::Core
     Pathname.new(root)
   end
 
+  def loader
+    Zeitwerk::Loader.new
+  end
+  memoize :loader
+
   def env
     env = ENV['JETS_ENV'] || 'development'
     ENV['RAILS_ENV'] = ENV['RACK_ENV'] = env

--- a/lib/jets/lambda/dsl.rb
+++ b/lib/jets/lambda/dsl.rb
@@ -404,10 +404,6 @@ module Jets::Lambda::Dsl
 
   def self.add_custom_resource_extensions(base)
     base_path = "#{Jets.root}/app/extensions"
-    unless ActiveSupport::Dependencies.autoload_paths.include?(base_path)
-      ActiveSupport::Dependencies.autoload_paths += [base_path]
-    end
-
     Dir.glob("#{base_path}/**/*.rb").each do |path|
       next unless File.file?(path)
 

--- a/lib/jets/stack.rb
+++ b/lib/jets/stack.rb
@@ -88,7 +88,6 @@ module Jets
       end
 
       def eager_load_shared_resources!
-        ActiveSupport::Dependencies.autoload_paths += ["#{Jets.root}/app/shared/resources"]
         Dir.glob("#{Jets.root}/app/shared/resources/**/*.rb").select do |path|
           next if !File.file?(path) or path =~ %r{/javascript/} or path =~ %r{/views/}
 

--- a/lib/jets/stack/main/dsl.rb
+++ b/lib/jets/stack/main/dsl.rb
@@ -22,8 +22,6 @@ class Jets::Stack
 
       def self.included(base)
         base_path = "#{Jets.root}/app/shared/extensions"
-        ActiveSupport::Dependencies.autoload_paths += [base_path]
-
         Dir.glob("#{base_path}/**/*.rb").each do |path|
           next unless File.file?(path)
 


### PR DESCRIPTION
* use zeitwerk as autoloader
* remove jets server `--reload` option
* adjust default autoload path
* fix shared functions docs

<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix. -->
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

Change the autoloader to use zeitwerk instead of ActiveSupport. This allows us to use hot-reloading for development and web requests pretty easily.

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

Related issues: #253 #240 

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
