### PR TITLE
dont add /dev prefix if on_cloud9

### DIFF
--- a/lib/jets/overrides/rails/common_methods.rb
+++ b/lib/jets/overrides/rails/common_methods.rb
@@ -9,13 +9,18 @@ module Jets::CommonMethods
   end
 
   def add_stage?(url)
+    return false if on_cloud9?
     request.host.include?("amazonaws.com") && url.starts_with?('/')
   end
   memoize :add_stage?
 
   def on_aws?
-    on_cloud9 = !!(request.headers['HTTP_HOST'] =~ /cloud9\..*\.amazonaws\.com/)
-    !request.headers['HTTP_X_AMZN_TRACE_ID'].nil? && !on_cloud9
+    !request.headers['HTTP_X_AMZN_TRACE_ID'].nil? && !on_cloud9?
   end
   memoize :on_aws?
+
+  def on_cloud9?
+    !!(request.headers['HTTP_HOST'] =~ /cloud9\..*\.amazonaws\.com/)
+  end
+  memoize :on_cloud9?
 end


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

Fixes bug when the /dev is added to urls to view helpers when hitting the cloud9 url. This is reproducible when running:

    jets server --port 8080 

And hitting the jets app with the cloud9 url and viewing the HTML source.

**Good**:

<img width="931" alt="url-good" src="https://user-images.githubusercontent.com/4085/58231499-05074780-7cec-11e9-8468-c88b7a0420ac.png">

**Bad**:

<img width="650" alt="url-bad" src="https://user-images.githubusercontent.com/4085/58231572-341db900-7cec-11e9-803f-53a32a5531ab.png">

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

https://community.rubyonjets.com/t/local-jets-server-causes-404-in-cloud9-because-of-dev-path-prefix/150/10

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
