### PR TITLE
dont generate handlers for concerns

### DIFF
--- a/lib/jets/commands/build.rb
+++ b/lib/jets/commands/build.rb
@@ -113,6 +113,7 @@ module Jets::Commands
       Dir.glob(expression).each do |path|
         return false unless File.file?(path)
         next unless app_file?(path)
+        next if concerns?(path)
 
         relative_path = path.sub("#{Jets.root}/", '')
         # Rids of the Jets.root at beginning
@@ -213,6 +214,10 @@ module Jets::Commands
       return true if includes.detect { |p| path.include?(p) }
 
       false
+    end
+
+    def self.concerns?(path)
+      path =~ %r{app/\w+/concerns/}
     end
 
     def self.tmp_code(full_build_path=false)


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

Jets deploy fails when there's a concerns module in the controllers folder. This fixes it by not generating unnecessary shim handlers for concerns.

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

https://community.rubyonjets.com/t/unable-to-autoload-constant-concerns-exceptionhandler/167

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
