### PR TITLE
fix stage name in dev mode for redirect also

### DIFF
--- a/lib/jets/controller.rb
+++ b/lib/jets/controller.rb
@@ -13,4 +13,5 @@ class Jets::Controller
   autoload :Rendering, "jets/controller/rendering"
   autoload :Request, "jets/controller/request"
   autoload :Response, "jets/controller/response"
+  autoload :Stage, "jets/controller/stage"
 end

--- a/lib/jets/controller/rendering.rb
+++ b/lib/jets/controller/rendering.rb
@@ -65,11 +65,7 @@ class Jets::Controller
     def add_stage_name(url)
       return url unless actual_host
 
-      if actual_host.include?("amazonaws.com") && url.starts_with?('/')
-        stage_name = Jets::Resource::ApiGateway::Deployment.stage_name
-        url = "/#{stage_name}#{url}"
-      end
-      url
+      Jets::Controller::Stage.add(actual_host, url)
     end
 
     def url_for(url)

--- a/lib/jets/controller/stage.rb
+++ b/lib/jets/controller/stage.rb
@@ -1,0 +1,33 @@
+class Jets::Controller
+  class Stage
+    def initialize(host, url)
+      @host, @url = host, url
+    end
+
+    def add
+      return @url unless add_stage?
+
+      stage_name = Jets::Resource::ApiGateway::Deployment.stage_name
+      "/#{stage_name}#{@url}"
+    end
+
+    def add_stage?
+      return false if on_cloud9?
+      @host.include?("amazonaws.com") && @url.starts_with?('/')
+    end
+
+    def on_cloud9?
+      self.class.on_cloud9?(@host)
+    end
+
+    class << self
+      def add(host, url)
+        new(host, url).add
+      end
+
+      def on_cloud9?(host)
+        !!(host =~ /cloud9\..*\.amazonaws\.com/)
+      end
+    end
+  end
+end

--- a/lib/jets/overrides/rails/common_methods.rb
+++ b/lib/jets/overrides/rails/common_methods.rb
@@ -2,25 +2,12 @@ module Jets::CommonMethods
   extend Memoist
   # Add API Gateway Stage Name
   def add_stage_name(url)
-    return url unless add_stage?(url)
-
-    stage_name = Jets::Resource::ApiGateway::Deployment.stage_name
-    "/#{stage_name}#{url}"
+    Jets::Controller::Stage.add(request.host, url)
   end
-
-  def add_stage?(url)
-    return false if on_cloud9?
-    request.host.include?("amazonaws.com") && url.starts_with?('/')
-  end
-  memoize :add_stage?
 
   def on_aws?
-    !request.headers['HTTP_X_AMZN_TRACE_ID'].nil? && !on_cloud9?
+    on_cloud9 = Jets::Controller::Stage.on_cloud9?(request.headers['HTTP_HOST'])
+    !request.headers['HTTP_X_AMZN_TRACE_ID'].nil? && !on_cloud9
   end
   memoize :on_aws?
-
-  def on_cloud9?
-    !!(request.headers['HTTP_HOST'] =~ /cloud9\..*\.amazonaws\.com/)
-  end
-  memoize :on_cloud9?
 end


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix. -->
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

In local development mode, when updating a record, Jets controllers redirect to a url that includes the `/dev` when using the cloud9 development endpoint.

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

https://community.rubyonjets.com/t/local-jets-server-causes-404-in-cloud9-because-of-dev-path-prefix/150/11

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
