### PR TITLE
Handle nil body on mega request proxy

### DIFF
--- a/lib/jets/mega/request.rb
+++ b/lib/jets/mega/request.rb
@@ -51,7 +51,7 @@ module Jets::Mega
       status = response.code.to_i
       headers = response.each_header.to_h
       encoding = get_encoding(headers['content-type'])
-      body = response.body.force_encoding(encoding)
+      body = response.body&.force_encoding(encoding)
       {
         status: status,
         headers: headers,

--- a/spec/lib/jets/mega/request_spec.rb
+++ b/spec/lib/jets/mega/request_spec.rb
@@ -28,6 +28,25 @@ describe Jets::Mega::Request do
         # pp resp # uncomment to see and debug
         expect(resp).to eq({:status=>200, :headers=>{}, :body=>"test body"})
       end
+
+      # Typical 304 Not Modified response
+      it "handles nil body" do
+        # Uncomment this stubbing to test live req
+        # Will need a rack server up and running
+        http = double(:http)
+        allow(http).to receive(:open_timeout=)
+        allow(http).to receive(:read_timeout=)
+        resp = double(:resp).as_null_object
+        allow(resp).to receive(:code).and_return("304")
+        allow(resp).to receive(:each_header).and_return({})
+        allow(resp).to receive(:body).and_return(nil)
+        allow(http).to receive(:request).and_return(resp)
+        allow(Net::HTTP).to receive(:new).and_return(http)
+
+        resp = req.proxy
+        # pp resp # uncomment to see and debug
+        expect(resp).to eq({:status=>304, :headers=>{}, :body=> nil})
+      end
     end
   end
 end


### PR DESCRIPTION
This is a 🐞 bug fix.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Mega request proxy is able to handle responses with `body: nil`. For example 304 Not Modified responses.
