### PR TITLE
only refresh routes on dev middleware request

### DIFF
--- a/lib/jets/application.rb
+++ b/lib/jets/application.rb
@@ -336,12 +336,11 @@ class Jets::Application
     @router ||= Jets::Router.new
   end
 
-  def load_routes
-    reload = Jets.env.development?
-    @router = nil if reload # clear_routes
+  def load_routes(refresh: false)
+    @router = nil if refresh # clear_routes
 
     routes_file = "#{Jets.root}/config/routes.rb"
-    if reload
+    if refresh
       load routes_file # always evaluate
     else
       require routes_file # evaluate once

--- a/lib/jets/controller/middleware/local/route_matcher.rb
+++ b/lib/jets/controller/middleware/local/route_matcher.rb
@@ -24,7 +24,7 @@ class Jets::Controller::Middleware::Local
       return unless Jets.env.development?
 
       Jets::Router.clear!
-      Jets.application.load_routes
+      Jets.application.load_routes(refresh: true)
     end
 
     def route_found?(route)


### PR DESCRIPTION
fixes bug so jets url shows up after jets deploy

<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

After a `jets deploy` it does not show the API Gateway endpoint url, this fixes it so it shows back up.

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

Regression fix for #264 

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
