### PR TITLE
Replace classify with camelize

### DIFF
--- a/lib/jets/booter.rb
+++ b/lib/jets/booter.rb
@@ -209,7 +209,7 @@ class Jets::Booter
                       .sub(%r{app\/\w+/concerns/},'')
                       .sub(%r{app/shared/\w+/},'') # remove shared/resources or shared/extensions
                       .sub(%r{app/\w+/},'') # remove app/controllers or app/jobs etc
-        class_name = class_name.classify
+        class_name = class_name.camelize
 
         if ENV['JETS_DEBUG_EAGER_LOAD']
           puts "path: #{path}"

--- a/lib/jets/commands/base.rb
+++ b/lib/jets/commands/base.rb
@@ -62,7 +62,7 @@ class Jets::Commands::Base < Thor
         class_name = path
                       .sub(/\.rb$/,'')
                       .sub(%r{.*/jets/commands}, 'jets/commands')
-                      .classify
+                      .camelize
         class_name = special_class_map(class_name)
         # NOTE: Weird thing where Jets::Commands::Db::Task => Thor::Command
         # because Task is a class available to Thor I believe.
@@ -124,7 +124,7 @@ class Jets::Commands::Base < Thor
         Jets::Commands::Main
       else
         class_name = namespace.gsub(':','/')
-        class_name = "Jets::Commands::#{class_name.classify}"
+        class_name = "Jets::Commands::#{class_name.camelize}"
         class_name = special_class_map(class_name)
         class_name.constantize
       end

--- a/lib/jets/commands/build.rb
+++ b/lib/jets/commands/build.rb
@@ -75,7 +75,7 @@ module Jets::Commands
     # path: app/jobs/easy_job.rb
     def build_child_template(path)
       md = path.match(%r{app/(.*?)/}) # extract: controller, job or function
-      process_class = md[1].camelize
+      process_class = md[1].classify
       builder_class = "Jets::Cfn::Builders::#{process_class}Builder".constantize
 
       # Examples:

--- a/lib/jets/commands/build.rb
+++ b/lib/jets/commands/build.rb
@@ -75,7 +75,7 @@ module Jets::Commands
     # path: app/jobs/easy_job.rb
     def build_child_template(path)
       md = path.match(%r{app/(.*?)/}) # extract: controller, job or function
-      process_class = md[1].classify
+      process_class = md[1].camelize
       builder_class = "Jets::Cfn::Builders::#{process_class}Builder".constantize
 
       # Examples:

--- a/lib/jets/commands/dynamodb/migrator.rb
+++ b/lib/jets/commands/dynamodb/migrator.rb
@@ -31,6 +31,6 @@ class Jets::Commands::Dynamodb::Migrator
   def get_migration_class
     filename = File.basename(@path, '.rb')
     filename = filename.sub(/\d+[-_]/, '') # strip leading timestsamp
-    filename.classify.constantize
+    filename.camelize.constantize
   end
 end

--- a/lib/jets/controller/rendering/rack_renderer.rb
+++ b/lib/jets/controller/rendering/rack_renderer.rb
@@ -225,7 +225,7 @@ module Jets::Controller::Rendering
           next unless File.file?(path)
           class_name = path.sub("#{project_root}/app/helpers/","").sub(/\.rb/,'')
           unless class_name == "application_helper"
-            klasses << class_name.classify.constantize # autoload
+            klasses << class_name.camelize.constantize # autoload
           end
         end
         klasses

--- a/lib/jets/klass.rb
+++ b/lib/jets/klass.rb
@@ -39,9 +39,9 @@ class Jets::Klass
     # app/controllers/posts_controller.rb => PostsController
     def class_name(path)
       if path.include?("/shared/")
-        path.sub(%r{.*app/shared/(.*?)/},'').sub(/\.rb$/,'').classify
+        path.sub(%r{.*app/shared/(.*?)/},'').sub(/\.rb$/,'').camelize
       else
-        path.sub(%r{.*app/(.*?)/},'').sub(/\.rb$/,'').classify
+        path.sub(%r{.*app/(.*?)/},'').sub(/\.rb$/,'').camelize
       end
     end
 

--- a/lib/jets/lambda/dsl.rb
+++ b/lib/jets/lambda/dsl.rb
@@ -407,7 +407,7 @@ module Jets::Lambda::Dsl
     Dir.glob("#{base_path}/**/*.rb").each do |path|
       next unless File.file?(path)
 
-      class_name = path.sub("#{base_path}/", '').sub(/\.rb/,'').classify
+      class_name = path.sub("#{base_path}/", '').sub(/\.rb/,'').camelize
       klass = class_name.constantize # autoload
       base.extend(klass)
     end

--- a/lib/jets/lambda/function_constructor.rb
+++ b/lib/jets/lambda/function_constructor.rb
@@ -44,7 +44,7 @@ module Jets::Lambda
     # for the class name.  We adjust it here.
     def adjust_tasks(klass)
       class_name = @code_path.to_s.sub(/.*\/functions\//,'').sub(/\.rb$/, '')
-      class_name = class_name.classify
+      class_name = class_name.camelize
       klass.tasks.each do |task|
         task.class_name = class_name
         task.type = "function"

--- a/lib/jets/poly_fun.rb
+++ b/lib/jets/poly_fun.rb
@@ -58,7 +58,7 @@ module Jets
       end
 
       # IE: Jets::PolyFun::PythonError
-      error_class = "Jets::PolyFun::#{task.lang.to_s.classify}Error".constantize
+      error_class = "Jets::PolyFun::#{task.lang.to_s.camelize}Error".constantize
       raise error_class.new(resp["errorMessage"], backtrace)
     end
 

--- a/lib/jets/preheat.rb
+++ b/lib/jets/preheat.rb
@@ -108,7 +108,7 @@ module Jets
         next unless path =~ %r{app/controllers} # only prewarm controllers
 
         class_path = path.sub(%r{.*app/\w+/},'').sub(/\.rb$/,'')
-        class_name = class_path.classify
+        class_name = class_path.camelize
         # IE: PostsController
         class_name.constantize # load app/**/* class definition
       end.compact

--- a/lib/jets/processors/deducer.rb
+++ b/lib/jets/processors/deducer.rb
@@ -56,7 +56,7 @@ class Jets::Processors::Deducer
     #   hello
     #   hello_function
 
-    class_name.classify
+    class_name.camelize
   end
 
   def load_class

--- a/lib/jets/resource/api_gateway/method.rb
+++ b/lib/jets/resource/api_gateway/method.rb
@@ -73,7 +73,7 @@ module Jets::Resource::ApiGateway
 
     def controller_auth_type
       controller_name = @route.to.split('#').first
-      controller = "#{controller_name}_controller".classify.constantize
+      controller = "#{controller_name}_controller".camelize.constantize
       # Already handles inheritance via class_attribute
       controller.authorization_type
     end

--- a/lib/jets/resource/child_stack/app_class.rb
+++ b/lib/jets/resource/child_stack/app_class.rb
@@ -84,7 +84,7 @@ module Jets::Resource::ChildStack
       @path.sub(templates_prefix, '')
         .sub(/\.yml$/,'')
         .gsub('-','/')
-        .classify
+        .camelize
     end
 
     # map the path to a camelized logical_id. Example:

--- a/lib/jets/resource/child_stack/shared.rb
+++ b/lib/jets/resource/child_stack/shared.rb
@@ -31,7 +31,7 @@ module Jets::Resource::ChildStack
       # add depends on parameters
       depends_on.each do |dependency|
         dependency_outputs(dependency).each do |output|
-          dependency_class = dependency.to_s.classify
+          dependency_class = dependency.to_s.camelize
           props[:parameters][output] = "!GetAtt #{dependency_class}.Outputs.#{output}"
         end
       end if depends_on
@@ -50,7 +50,7 @@ module Jets::Resource::ChildStack
 
     # Returns output keys associated with the stack.  They are the resource logical ids.
     def dependency_outputs(dependency)
-      dependency.to_s.classify.constantize.output_keys
+      dependency.to_s.camelize.constantize.output_keys
     end
 
     def depends_on
@@ -74,7 +74,7 @@ module Jets::Resource::ChildStack
       @path.sub(templates_prefix, '')
         .sub(/\.yml$/,'')
         .gsub('-','/')
-        .classify
+        .camelize
         .constantize # returns actual class
     end
 

--- a/lib/jets/stack.rb
+++ b/lib/jets/stack.rb
@@ -95,7 +95,7 @@ module Jets
                         .sub(/\.rb$/,'') # remove .rb
                         .sub("#{Jets.root}/",'') # remove ./
                         .sub(%r{app/shared/resources/},'') # remove app/shared/resources/
-                        .classify
+                        .camelize
           class_name.constantize # use constantize instead of require so dont have to worry about order.
         end
       end

--- a/lib/jets/stack/depends.rb
+++ b/lib/jets/stack/depends.rb
@@ -11,7 +11,7 @@ class Jets::Stack
       @items.each do |item|
         logical_id = item.stack.to_s.camelize # logical_id
         dependency_outputs(logical_id).each do |output|
-          dependency_class = logical_id.to_s.classify
+          dependency_class = logical_id.to_s.camelize
           output_key = item.options[:class_prefix] ?
             "#{dependency_class}#{output}" : # already camelized
             output
@@ -30,7 +30,7 @@ class Jets::Stack
     end
 
     def dependency_outputs(logical_id)
-      logical_id.to_s.classify.constantize.output_keys
+      logical_id.to_s.camelize.constantize.output_keys
     end
   end
 end

--- a/lib/jets/stack/main/dsl.rb
+++ b/lib/jets/stack/main/dsl.rb
@@ -25,7 +25,7 @@ class Jets::Stack
         Dir.glob("#{base_path}/**/*.rb").each do |path|
           next unless File.file?(path)
 
-          class_name = path.sub("#{base_path}/", '').sub(/\.rb/,'').classify
+          class_name = path.sub("#{base_path}/", '').sub(/\.rb/,'').camelize
           klass = class_name.constantize # autoload
           base.extend(klass)
         end

--- a/lib/jets/stack/output/lookup.rb
+++ b/lib/jets/stack/output/lookup.rb
@@ -7,7 +7,7 @@ class Jets::Stack::Output
     end
 
     def output(logical_id)
-      child_stack_id = @stack_subclass.to_s.classify
+      child_stack_id = @stack_subclass.to_s.camelize
 
       stack_arn = shared_stack_arn(child_stack_id)
       resp = cfn.describe_stacks(stack_name: stack_arn)

--- a/lib/jets/stack/parameter/dsl.rb
+++ b/lib/jets/stack/parameter/dsl.rb
@@ -27,7 +27,7 @@ class Jets::Stack
 
       # Returns output keys associated with the stack.  They are the resource logical ids.
       def dependency_outputs(dependency)
-        dependency.to_s.classify.constantize.output_keys
+        dependency.to_s.camelize.constantize.output_keys
       end
 
       class_methods do


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

Been mistakenly using classify instead of camelize to convert words to their class names. This fixes that. Normally, if your class names were plural, then this might break your app.  However, because Jets does an eager load of the app as a sanity check before deploying, in theory should not break your app since it prevent your app from deploying anyway. See #227 

Will be bumping a minor version for this.

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

Related to #227

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

minor