### PR TITLE
Fix starter crud.js due to core-js module

### DIFF
--- a/lib/jets/commands/templates/webpacker/app/javascript/src/jets/crud.js
+++ b/lib/jets/commands/templates/webpacker/app/javascript/src/jets/crud.js
@@ -36,7 +36,7 @@ $(function() {
     var submit = $(e.target);
     var form = submit.closest('form');
     var url = form.attr("action");
-    var method = form.find("input[name=_method]");
+    var method = $("input[name=_method]");
 
     if (method.attr("value") != "put") {
       return true;


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

Looks like core-js module removed Array.find. This breaks the starter crud.js as babel is not able to compile it. Using $ instead.

* use $ finder instead of .find

<details>
 <summary>Error when running bin/webpack</summary>

    $ JETS_ENV=development bin/webpack                          
    
    WARNING: We noticed you're using the `useBuiltIns` option without declaring a core-js version. Currently, we assume version 2.x when no version is passed. Since this default version will likely change in future versions of Babel, we recommend explicitly setting the core-js version you are using via the `corejs` option.
    
    You should also be sure that the version you pass to the `corejs` option matches the version specified in your `package.json`'s `dependencies` section. If it doesn't, you need to run one of the following commands:
    
      npm install --save core-js@2    npm install --save core-js@3
      yarn add core-js@2              yarn add core-js@3
    
    
    The uglify target has been deprecated. Set the top level
    option `forceAllTransforms: true` instead.
    
    Hash: 16f1fa2518008809fbec
    Version: webpack 4.32.2
    Time: 1717ms
    Built at: 2019-05-28 17:08:23
                                         Asset       Size       Chunks             Chunk Names
                        css/theme-c25cd454.css  252 bytes        theme  [emitted]  theme
                    css/theme-c25cd454.css.map  564 bytes        theme  [emitted]  theme
        js/application-f08563095cc88e98aaa5.js    310 KiB  application  [emitted]  application
    js/application-f08563095cc88e98aaa5.js.map    366 KiB  application  [emitted]  application
              js/theme-8d93dc0cc7011472ae21.js   3.93 KiB        theme  [emitted]  theme
          js/theme-8d93dc0cc7011472ae21.js.map   3.61 KiB        theme  [emitted]  theme
                                 manifest.json  901 bytes               [emitted]  
    Entrypoint application = js/application-f08563095cc88e98aaa5.js js/application-f08563095cc88e98aaa5.js.map
    Entrypoint theme = css/theme-c25cd454.css js/theme-8d93dc0cc7011472ae21.js css/theme-c25cd454.css.map js/theme-8d93dc0cc7011472ae21.js.map
    [./app/javascript/packs/application.js] 550 bytes {application} [built]
    [./app/javascript/packs/theme.scss] 39 bytes {theme} [built]
    [./app/javascript/src/jets/crud.js] 2.2 KiB {application} [built]
    [./node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 552 bytes {application} [built]
        + 2 hidden modules
    
    ERROR in ./app/javascript/src/jets/crud.js
    Module not found: Error: Can't resolve 'core-js/modules/es6.array.find' in '/home/ec2-user/environment/demo/app/javascript/src/jets'
     @ ./app/javascript/src/jets/crud.js 1:0-40
     @ ./app/javascript/packs/application.js
    Child mini-css-extract-plugin node_modules/css-loader/dist/cjs.js??ref--7-1!node_modules/postcss-loader/src/index.js??ref--7-2!node_modules/sass-loader/lib/loader.js??ref--7-3!app/javascript/packs/theme.scss:
        Entrypoint mini-css-extract-plugin = *
        [./node_modules/css-loader/dist/cjs.js?!./node_modules/postcss-loader/src/index.js?!./node_modules/sass-loader/lib/loader.js?!./app/javascript/packs/theme.scss] ./node_modules/css-loader/dist/cjs.js??ref--7-1!./node_modules/postcss-loader/src??ref--7-2!./node_modules/sass-loader/lib/loader.js??ref--7-3!./app/javascript/packs/theme.scss 983 bytes {mini-css-extract-plugin} [built]
            + 1 hidden module
    $ 
</details>

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
