### PR TITLE
fix deploy for job mode with no config/routes.rb file

### DIFF
--- a/lib/jets/application.rb
+++ b/lib/jets/application.rb
@@ -340,6 +340,7 @@ class Jets::Application
     @router = nil if refresh # clear_routes
 
     routes_file = "#{Jets.root}/config/routes.rb"
+    return unless File.exist?(routes_file)
     if refresh
       load routes_file # always evaluate
     else


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

Fixes `jets deploy` for job mode when there's no `config/routes.rb` file.

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

Bug report #270

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
