### PR TITLE
remove jets-gems as vendor dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/jets-gems"]
-	path = vendor/jets-gems
-	url = https://github.com/tongueroo/jets-gems

--- a/jets.gemspec
+++ b/jets.gemspec
@@ -27,9 +27,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "actionmailer", "~> 5.2.1"
   spec.add_dependency "actionpack", "~> 5.2.1"
   spec.add_dependency "actionview", "~> 5.2.1"
-  spec.add_dependency "actionmailer", "~> 5.2.1"
   spec.add_dependency "activerecord", "~> 5.2.1"
   spec.add_dependency "activesupport", "~> 5.2.1"
   spec.add_dependency "aws-sdk-apigateway"
@@ -45,6 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dotenv"
   spec.add_dependency "gems" # jets-gems dependency
   spec.add_dependency "hashie"
+  spec.add_dependency "jets-gems"
   spec.add_dependency "jets-html-sanitizer"
   spec.add_dependency "json"
   spec.add_dependency "kramdown"

--- a/lib/jets.rb
+++ b/lib/jets.rb
@@ -8,6 +8,7 @@ require "active_support/ordered_options"
 require "fileutils"
 require "memoist"
 require "rainbow/ext/string"
+require "jets/gems"
 
 require "jets/autoloaders"
 Jets::Autoloaders.log! if ENV["JETS_AUTOLOAD_LOG"]
@@ -18,10 +19,5 @@ module Jets
   class Error < StandardError; end
   extend Core # root, logger, etc
 end
-
-root = File.expand_path("..", __dir__)
-
-$:.unshift("#{root}/vendor/jets-gems/lib")
-require "jets-gems"
 
 Jets::Autoloaders.once.preload("#{__dir__}/jets/db.rb") # required for booter.rb: setup_db


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix. -->
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

Removes the vendor/jets-gem. Using gem now.

