### PR TITLE
warn about bundler/setup failure

### DIFF
--- a/lib/jets/bundle.rb
+++ b/lib/jets/bundle.rb
@@ -18,6 +18,8 @@ module Jets
       return unless bundler_enabled?
       Kernel.require "bundler/setup"
       Bundler.setup # Same as Bundler.setup(:default)
+    rescue LoadError => e
+      handle_error(e)
     end
 
     # Bundler.require called when environment boots up via Jets.boot.  This will eagerly require all gems in the
@@ -39,6 +41,27 @@ module Jets
       return unless bundler_enabled?
       Kernel.require "bundler/setup"
       Bundler.require(*bundler_groups)
+    rescue LoadError => e
+      handle_error(e)
+    end
+
+    def handle_error(e)
+      puts e.message
+      puts <<~EOL.color(:yellow)
+        WARNING: Unable to require "bundler/setup"
+        There may be something funny with your ruby and bundler setup.
+        You can try upgrading bundler and rubygems:
+
+            gem update --system
+            gem install bundler
+
+        Here are some links that may be helpful:
+
+        * https://bundler.io/blog/2019/01/03/announcing-bundler-2.html
+        * https://community.rubyonjets.com/t/jets-1-9-8-install-issue-bundler-setup-missing/185/2
+
+        Also, running bundle exec in front of your command may remove this message.
+      EOL
     end
 
     # Also check for Afterburner mode since in that mode jets is a standalone tool.


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

On some systems, there's a ruby and bundler issue where `require "bundler/setup"` throws an error.  Think this may be because `bundler.rb` exists at 2 places. Found them here on my system:

    $ find /home/ec2-user/.rbenv/versions/2.5.3/ -name bundler.rb
    /home/ec2-user/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/bundler-2.0.1/lib/bundler.rb
    /home/ec2-user/.rbenv/versions/2.5.3/lib/ruby/site_ruby/2.5.0/bundler.rb
    $ 

When the `site_ruby/2.5.0/bundler.rb` is older or does not have `bundler/setup.rb` it will cause an LoadError.  This was reported in the community forums.  Removing `site_ruby/2.5.0/bundler/setup.rb` mimics the error:


    $ jets server
    Traceback (most recent call last):
            13: from /home/ec2-user/.rbenv/versions/2.5.3/bin/jets:23:in `<main>'
            12: from /home/ec2-user/.rbenv/versions/2.5.3/bin/jets:23:in `load'
            11: from /home/ec2-user/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/jets-1.9.8/exe/jets:13:in `<top (required)>'
            10: from /home/ec2-user/.rbenv/versions/2.5.3/lib/ruby/site_ruby/2.5.0/rubygems/core_ext/kernel_require.rb:54:in `require'
             9: from /home/ec2-user/.rbenv/versions/2.5.3/lib/ruby/site_ruby/2.5.0/rubygems/core_ext/kernel_require.rb:54:in `require'
             8: from /home/ec2-user/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/jets-1.9.8/lib/jets.rb:13:in `<top (required)>'
             7: from /home/ec2-user/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require'
             6: from /home/ec2-user/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:257:in `load_dependency'
             5: from /home/ec2-user/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `block in require'
             4: from /home/ec2-user/.rbenv/versions/2.5.3/lib/ruby/site_ruby/2.5.0/rubygems/core_ext/kernel_require.rb:54:in `require'
             3: from /home/ec2-user/.rbenv/versions/2.5.3/lib/ruby/site_ruby/2.5.0/rubygems/core_ext/kernel_require.rb:54:in `require'
             2: from /home/ec2-user/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/jets-1.9.8/lib/jets/autoloaders.rb:2:in `<top (required)>'
             1: from /home/ec2-user/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/jets-1.9.8/lib/jets/bundle.rb:19:in `setup'
    /home/ec2-user/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/jets-1.9.8/lib/jets/bundle.rb:19:in `require': cannot load such file -- bundler/setup (LoadError)

Calling commands with `bundle exec` will work though.

    $ bundle exec jets server                                                 
    => bundle exec rackup --port 8888 --host 127.0.0.1
    Jets booting up in development mode!
    [2019-05-31 04:44:18] INFO  WEBrick 1.4.2
    [2019-05-31 04:44:18] INFO  ruby 2.5.3 (2018-10-18) [x86_64-linux]
    [2019-05-31 04:44:18] INFO  WEBrick::HTTPServer#start: pid=1124 port=8888

Think because is `bundle exec` will adjust the $LOAD_PATH early enough so that the bundler in the gems path not the site_ruby path is required first.

## Solution

The workaround solution right now is to print a warning messaging to the user and suggest them to fix their ruby and bundler installation. Here's what the fix looks like:

    $ jets server                                                 
    cannot load such file -- bundler/setup
    WARNING: Unable to require "bundler/setup"
    There may be something funny with your ruby and bundler setup.
    You can try upgrading bundler and rubygems:
    
        gem update --system
        gem install bundler
    
    Here are some links that may be helpful:
    
    * https://bundler.io/blog/2019/01/03/announcing-bundler-2.html
    * https://community.rubyonjets.com/t/jets-1-9-8-install-issue-bundler-setup-missing/185/2
    
    Also, running bundle exec in front of your command may remove this message.
    
    => bundle exec rackup --port 8888 --host 127.0.0.1
    Jets booting up in development mode!
    [2019-05-31 04:48:47] INFO  WEBrick 1.4.2
    [2019-05-31 04:48:47] INFO  ruby 2.5.3 (2018-10-18) [x86_64-linux]
    [2019-05-31 04:48:47] INFO  WEBrick::HTTPServer#start: pid=1730 port=8888


## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

https://community.rubyonjets.com/t/jets-1-9-8-install-issue-bundler-setup-missing/185/3

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
