### PR TITLE
optimize by moving reloader middleware after the shotgun static 

### DIFF
--- a/lib/jets/middleware/default_stack.rb
+++ b/lib/jets/middleware/default_stack.rb
@@ -8,11 +8,11 @@ module Jets::Middleware
 
     def build_stack
       Stack.new do |middleware|
-        middleware.use Jets::Controller::Middleware::Reloader if Jets.env.development?
         middleware.use Shotgun::Static if Jets.env.development?
         middleware.use Rack::Runtime
         middleware.use Jets::Controller::Middleware::Cors if cors_enabled?
         middleware.use Rack::MethodOverride # must come before Middleware::Local for multipart post forms to work
+        middleware.use Jets::Controller::Middleware::Reloader if Jets.env.development?
         middleware.use Jets::Controller::Middleware::Local # mimics AWS Lambda for local server only
         middleware.use session_store, session_options # use session_store, session_options
         middleware.use Rack::Head


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

Optimize development middleware by moving the reloader middleware after the shotgun static middleware. This allows the static middleware to serve static assets without hitting the `@@reload_lock` mutex. So static assets can be served in parallel locally. For apps with a lot of static assets, this is a good win.

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

#283 #284 

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
