### PR TITLE
add sqs url to shared sqs queue resource

### DIFF
--- a/docs/_docs/events/sns.md
+++ b/docs/_docs/events/sns.md
@@ -22,7 +22,7 @@ We'll cover each of them:
 Here is an example connecting an existing SNS topic to a Lambda function in a [Job]({% link _docs/jobs.md %})
 
 ```ruby
-class HardJob
+class HardJob < ApplicationJob
   class_timeout 30 # must be less than or equal to the SNS Topic default timeout
   sns_event "hello-topic"
   def dig
@@ -44,7 +44,7 @@ There's more information on the filter_policy here on [SNS Message Filtering](ht
 Jets can create and manage an SNS Topic for a specific function. This is done with a special `:generate_topic` argument.
 
 ```ruby
-class HardJob
+class HardJob < ApplicationJob
   class_timeout 30 # must be less than or equal to the SNS Topic default timeout
   sns_event :generate_topic
   def lift
@@ -86,7 +86,7 @@ You can reference the Shared Topic like so:
 app/jobs/hard_job.rb:
 
 ```ruby
-class HardJob
+class HardJob < ApplicationJob
   depends_on :topic # so we can reference topic shared resources
   sns_event ref(:engineering) # reference sns topic in shared resource
   def fix

--- a/docs/_docs/events/sqs.md
+++ b/docs/_docs/events/sqs.md
@@ -21,7 +21,7 @@ We'll cover each of them:
 Here is an example connecting an existing SQS queue to a Lambda function in a [Job]({% link _docs/jobs.md %})
 
 ```ruby
-class HardJob
+class HardJob < ApplicationJob
   class_timeout 30 # must be less than or equal to the SQS queue default timeout
   sqs_event "hello-queue"
   def dig
@@ -41,7 +41,7 @@ Ultimately, the `sqs_event` declaration generates a [Lambda::EventSourceMapping]
 Jets can create and manage an SQS queue for a specific function. This is done with a special `:generate_queue` argument.
 
 ```ruby
-class HardJob
+class HardJob < ApplicationJob
   class_timeout 30 # must be less than or equal to the SQS queue default timeout
   sqs_event :generate_queue
   def lift
@@ -83,12 +83,14 @@ You can reference the Shared Queue like so:
 app/jobs/hard_job.rb:
 
 ```ruby
-class HardJob
+class HardJob < ApplicationJob
   class_timeout 30 # must be less than or equal to the SQS queue default timeout
   depends_on :list # so we can reference list shared resources
   sqs_event ref(:waitlist) # reference sqs queue in shared resource
   def fix
     puts "fix #{JSON.dump(event)}"
+    puts "sqs arn: #{List.lookup(:waitlist)}"
+    puts "sqs url: #{List.lookup(:waitlist_url)}"
   end
 end
 ```

--- a/lib/jets/resource/child_stack/shared.rb
+++ b/lib/jets/resource/child_stack/shared.rb
@@ -55,7 +55,7 @@ module Jets::Resource::ChildStack
 
     def depends_on
       return unless current_shared_class.depends_on
-      current_shared_class.depends_on.map { |x| x.to_s.singularize.camelize }
+      current_shared_class.depends_on.map { |x| x.to_s.camelize }
     end
 
     # map the path to a camelized logical_id. Example:

--- a/lib/jets/stack/main/dsl/sqs.rb
+++ b/lib/jets/stack/main/dsl/sqs.rb
@@ -3,8 +3,8 @@ module Jets::Stack::Main::Dsl
     def sqs_queue(id, props={})
       # props[:queue_name] ||= id.to_s # comment out to allow CloudFormation to generate name
       resource(id, "AWS::SQS::Queue", props)
-      # output(id) # normal !Ref returns the sqs url the ARN is more useful
-      output(id, getatt(id, :arn))
+      output(id, getatt(id, :arn)) # normal !Ref returns the sqs url the ARN is useful for nested stacks depends_on
+      output("#{id}_url", ref(id)) # useful for Stack.lookup method. IE: List.lookup(:waitlist_url)
     end
   end
 end


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

Add sqs url to shared sqs queue resource output. This allows us to grab the sqs url programatically. Example: `List.lookup(:waitlist_url)`.

app/shared/resources/list.rb:

```ruby
class List < Jets::Stack
  sqs_queue(:waitlist)
end
```

app/jobs/hard_job.rb:

```ruby
class HardJob < ApplicationJob
  class_timeout 30 # must be less than or equal to the SQS queue default timeout
  depends_on :list # so we can reference list shared resources
  sqs_event ref(:waitlist) # reference sqs queue in shared resource
  def fix
    puts "fix #{JSON.dump(event)}"
    puts "sqs arn: #{List.lookup(:waitlist)}"
    puts "sqs url: #{List.lookup(:waitlist_url)}"
  end
end
```

Also:

* fix bug with camelize of the shared resource class name, not using using singularize
* also fix sqs event docs

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

https://community.rubyonjets.com/t/sqs-queues-and-messages/187

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
