### PR TITLE
allow adjustment for preheat job iam policy

### DIFF
--- a/docs/_docs/iam-policies.md
+++ b/docs/_docs/iam-policies.md
@@ -5,7 +5,7 @@ nav_order: 16
 
 Jets provides several ways to finely control the IAM policies associated with your Lambda functions. Here are the ways and their precedence:
 
-1. Function specific IAM policy: highest precedence
+1. Function-specific IAM policy: highest precedence
 2. Class-wide IAM policy
 3. Application-wide IAM policy: lowest precedence
 
@@ -46,7 +46,7 @@ end
 
 ## IAM Policies Inheritance
 
-IAM policies defined at lower levels of precedence **inherit** and include the policies from the higher levels of precedence. This is done so you do not have to duplicate your IAM policies when you only need to add a simple additional permission. For example, the default application-wide IAM policy looks something like this:
+IAM policies defined at lower levels of precedence **inherit** and include the policies from the higher levels of precedence. This is done so you do not have to duplicate your IAM policies when you only need to add simple additional permissions. For example, the default application-wide IAM policy looks something like this:
 
 ```ruby
 [{
@@ -90,6 +90,7 @@ If you would like to override the default Application-wide IAM policy in `config
 
 ```ruby
 Jets.application.configure do |config|
+  # ...
   config.iam_policy = [
     Jets::Application.default_iam_policy,
     {
@@ -102,6 +103,19 @@ end
 ```
 
 This is useful because the Jets default application IAM policy is dynamically calculated depending on what the resources are being provisioned.  For example, using [Shared Resources]({% link _docs/shared-resources.md %}) will add CloudFormation read permissions.
+
+## Prewarm Job IAM Policy
+
+Jets supports [Prewarming]({% link _docs/prewarming.md %}) by creating an internal [Jets::PreheatJob](https://github.com/tongueroo/jets/blob/master/lib/jets/internal/app/jobs/jets/preheat_job.rb) class.  The PreheatJob has it's own IAM policy that allows it to call Lambda functions. It may be useful to adjust the policy if you are using Lambda with vpc_config. Here's an example:
+
+```ruby
+Jets.application.configure do |config|
+  # ...
+  config.prewarm_job_iam_policy = [
+    Jets::Application.default_prewarm_job_iam_policy,
+    "ec2"
+  ]
+```
 
 ## IAM Policy Definition Styles
 

--- a/lib/jets/application.rb
+++ b/lib/jets/application.rb
@@ -187,6 +187,7 @@ class Jets::Application
   def set_iam_policy
     config.iam_policy ||= self.class.default_iam_policy
     config.managed_policy_definitions ||= [] # default empty
+    config.prewarm_job_iam_policy ||= self.class.default_prewarm_job_iam_policy
   end
 
   def self.default_iam_policy
@@ -218,6 +219,23 @@ class Jets::Application
       policies << cloudformation
     end
     policies
+  end
+
+  def self.default_prewarm_job_iam_policy
+    [
+      {
+        sid: "Statement1",
+        action: ["logs:*"],
+        effect: "Allow",
+        resource: "arn:aws:logs:#{Jets.aws.region}:#{Jets.aws.account}:log-group:#{Jets.config.project_namespace}-*",
+      },
+      {
+        sid: "Statement2",
+        action: ["lambda:InvokeFunction", "lambda:InvokeAsync"],
+        effect: "Allow",
+        resource: "arn:aws:lambda:#{Jets.aws.region}:#{Jets.aws.account}:function:#{Jets.config.project_namespace}-*",
+      }
+    ]
   end
 
   # It is pretty easy to attempt to set environment variables without

--- a/lib/jets/internal/app/jobs/jets/preheat_job.rb
+++ b/lib/jets/internal/app/jobs/jets/preheat_job.rb
@@ -7,20 +7,7 @@ class Jets::PreheatJob < ApplicationJob
 
   class_timeout 30
   class_memory 1024
-  class_iam_policy(
-    {
-      sid: "Statement1",
-      action: ["logs:*"],
-      effect: "Allow",
-      resource: "arn:aws:logs:#{Jets.aws.region}:#{Jets.aws.account}:log-group:#{Jets.config.project_namespace}-*",
-    },
-    {
-      sid: "Statement2",
-      action: ["lambda:InvokeFunction", "lambda:InvokeAsync"],
-      effect: "Allow",
-      resource: "arn:aws:lambda:#{Jets.aws.region}:#{Jets.aws.account}:function:#{Jets.config.project_namespace}-*",
-    }
-  )
+  class_iam_policy(Jets.config.prewarm_job_iam_policy)
 
   rate(PREWARM_RATE) if torching
   def torch


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

Brought up in Jets community: [WarmLambdaFunction, TorchLambdaFunction dose not use my configured role](https://community.rubyonjets.com/t/warmlambdafunction-torchlambdafunction-dose-not-use-my-configured-role/188) 

This allows users to adjust the generated IAM policy associated with the [Jets::PreheatJob](https://github.com/tongueroo/jets/blob/master/lib/jets/internal/app/jobs/jets/preheat_job.rb) that handles [Prewarming](https://rubyonjets.com/docs/prewarming/)

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

https://community.rubyonjets.com/t/warmlambdafunction-torchlambdafunction-dose-not-use-my-configured-role/188

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
