### PR TITLE
dotenv env extra support, fix precedence again

### DIFF
--- a/docs/_docs/env-files.md
+++ b/docs/_docs/env-files.md
@@ -32,7 +32,26 @@ If you add ".remote" to the end of the filename, Jets will only load the values 
 
 To use the remote version within the `jets console`, you can use the `JETS_ENV_REMOTE=1` env variable. Example:
 
-    JETS_ENV=development JETS_ENV_REMOTE=1 jets console
+    JETS_ENV_REMOTE=1 jets console
+
+## Jets Env Extra
+
+The [JETS_ENV_EXTRA]({% link _docs/env-extra.md %}) concept supports its own dotenv file.  Example:
+
+    JETS_ENV_EXTRA=2 jets console
+
+Loads `.env.development.2`. This takes the highest precedence and will override values in other dotenv files.
+
+## Dotenv File Precedence
+
+Here's an example with `JETS_ENV=development` to explain the dotenv files precedence, from highest to lowest.
+
+1. .env.development.2 (highest) - Loaded when `JETS_ENV_EXTRA=2` is set
+2. .env.development.remote - Loaded when `JETS_ENV_REMOTE=1` is set
+3. .env.development.local
+4. .env.development
+5. .env.local - Loaded for all environments _except_ `test`.
+6. .env - (lowest) - Always loaded
 
 ## SSM Parameter Store Support
 

--- a/lib/jets/dotenv.rb
+++ b/lib/jets/dotenv.rb
@@ -6,23 +6,22 @@ class Jets::Dotenv
   end
 
   def initialize(remote=false)
-    @remote = remote
-    @remote = ENV['JETS_ENV_REMOTE'] if ENV['JETS_ENV_REMOTE']
+    @remote = ENV['JETS_ENV_REMOTE'] || remote
   end
 
   def load!
     vars = ::Dotenv.load(*dotenv_files)
-    ssm = Ssm.new(vars)
-    ssm.interpolate!
+    Ssm.new(vars).interpolate!
   end
 
   # dotenv files with the following precedence:
   #
-  # - .env.development.remote (highest)
+  # - .env.development.jets_env_extra (highest)
+  # - .env.development.remote (2nd highest)
   # - .env.development.local
   # - .env.development
   # - .env.local - This file is loaded for all environments _except_ `test`.
-  # - .env` - The original (lowest)
+  # - .env - The original (lowest)
   #
   def dotenv_files
     files = [
@@ -32,7 +31,10 @@ class Jets::Dotenv
       root.join(".env.#{Jets.env}.local"),
     ]
     files << root.join(".env.#{Jets.env}.remote") if @remote
-    files.reverse.compact # reverse so the precedence is right
+    if ENV["JETS_ENV_EXTRA"]
+      files << root.join(".env.#{Jets.env}.#{ENV["JETS_ENV_EXTRA"]}")
+    end
+    files.compact
   end
 
   def root


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
This is a 🧐 documentation change.

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

Added support so that `.env.development.2` when `JETS_ENV_EXTRA=2` is set is loaded. 

In working on this, discovered the dotenv precedence was incorrect again? A little confused by this as though I had fixed this. Here are some related links to show the history:

* #171 fix precedence of dotenv files - from https://community.rubyonjets.com/t/local-and-remote-environment/75/4
* #214 Update dotenv.rb - had closed this PR because when I tested it, at the time, the precedence order was right
* There's a report on the dotenv project also that may be related: https://github.com/bkeepers/dotenv/issues/392

When when I tested today, the precedence was incorrect again... Thought it might change in one of the dotenv versions. But tested these versions of dotenv: 2.7.2, 2.6.0, 2.5.0, 2.0.2, 1.0.2 and it behaves consistently.  Currently, the last file loaded takes the highest precedence. So don't think it's a dotenv version thing. 

Thought maybe it's a system specific issue? But tested on cloud9 and macosx and the behavior is consistent. The last file in the Dotenv.load call takes highest precedence.

Tested it enough to say that it looks like this is the right fix. Posted these notes for posterity in case others run into it like in #214. 

