### PR TITLE
No network boot

### DIFF
--- a/lib/jets/aws_info.rb
+++ b/lib/jets/aws_info.rb
@@ -49,6 +49,8 @@ module Jets
     # aws sts get-caller-identity
     def account
       return '123456789' if test?
+      return ENV['JETS_AWS_ACCOUNT'] if ENV['JETS_AWS_ACCOUNT']
+
       # ensure region set, required for sts.get_caller_identity.account to work
       ENV['AWS_REGION'] ||= region
       begin

--- a/lib/jets/dotenv.rb
+++ b/lib/jets/dotenv.rb
@@ -10,8 +10,13 @@ class Jets::Dotenv
   end
 
   def load!
+    return if on_aws? # this prevents ssm calls if used in dotenv files
     vars = ::Dotenv.load(*dotenv_files)
     Ssm.new(vars).interpolate!
+  end
+
+  def on_aws?
+    !!ENV['_HANDLER'] # https://docs.aws.amazon.com/lambda/latest/dg/lambda-environment-variables.html
   end
 
   # dotenv files with the following precedence:

--- a/lib/jets/resource/lambda/function/environment.rb
+++ b/lib/jets/resource/lambda/function/environment.rb
@@ -19,6 +19,7 @@ class Jets::Resource::Lambda::Function
       env[:JETS_ENV_EXTRA] = Jets.config.env_extra if Jets.config.env_extra
       env[:JETS_PROJECT_NAME] = ENV['JETS_PROJECT_NAME'] if ENV['JETS_PROJECT_NAME']
       env[:JETS_STAGE] = Jets::Resource::ApiGateway::Deployment.stage_name
+      env[:JETS_AWS_ACCOUNT] = Jets.aws.account
       env
     end
 


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

The Jets boot process calls the sts get-caller-identity api to get info about region and account id. This network call can sometimes error. So removing the need to make network calls from the bootup process.

Also, removes ssm calls from Jets bootup process. So kills 2 birds with one stone here.

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

* https://community.rubyonjets.com/t/jets-once-sometime-stuck-with-init-seahorse-networkingerror-error-on-aws-lambda/201
* #297 


## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
