### PR TITLE
API Gateway: Limit resource names to 62 (!) characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project *loosely tries* to adhere to [Semantic Versioning](http://semver.org/).
 
+## [UNRELEASED]
+- API Gateway: Do not generate resource names longer than 62 characters
+
 ## [1.9.28]
 - #302 improve jets call guesser, do a simple detection at the start
 

--- a/lib/jets/controller/callbacks.rb
+++ b/lib/jets/controller/callbacks.rb
@@ -16,6 +16,10 @@ class Jets::Controller
           self.before_actions = [[meth, options]] + self.before_actions
         end
 
+        def skip_before_action(meth)
+          self.before_actions = self.before_actions.reject { |el| el.first.to_s == meth.to_s }
+        end
+
         alias_method :append_before_action, :before_action
 
         def after_action(meth, options={})
@@ -24,6 +28,10 @@ class Jets::Controller
 
         def prepend_after_action(meth, options={})
           self.after_actions = [[meth, options]] + self.after_actions
+        end
+
+        def skip_after_action(meth)
+          self.after_actions = self.after_actions.reject { |el| el.first.to_s == meth.to_s }
         end
 
         alias_method :append_after_action, :after_action

--- a/lib/jets/resource.rb
+++ b/lib/jets/resource.rb
@@ -21,7 +21,20 @@ class Jets::Resource
     id = template.keys.first
     # replace possible {namespace} in the logical id
     id = replacer.replace_value(id)
-    Jets::Camelizer.camelize(id)
+    id = Jets::Camelizer.camelize(id)
+
+    Jets::Resource.truncate_id(id)
+  end
+
+  def self.truncate_id(id)
+    # Api Gateway resource name has a limit of 64 characters.
+    # Yet it throws not found when ID is longer than 62 characters and I don't know why.
+    # To keep it safe, let's stick to the 62 characters limit.
+    if id.size > 62
+      "#{id[0..55]}#{Digest::MD5.hexdigest(id)[0..5]}"
+    else
+      id
+    end
   end
 
   def type

--- a/lib/jets/resource/api_gateway/method.rb
+++ b/lib/jets/resource/api_gateway/method.rb
@@ -81,7 +81,7 @@ module Jets::Resource::ApiGateway
     def resource_id
       @route.path == '' ?
        "RootResourceId" :
-       "#{resource_logical_id.camelize}ApiResource"
+       Jets::Resource.truncate_id("#{resource_logical_id.camelize}ApiResource")
     end
 
     # Example: Posts

--- a/lib/jets/resource/api_gateway/resource.rb
+++ b/lib/jets/resource/api_gateway/resource.rb
@@ -28,7 +28,7 @@ module Jets::Resource::ApiGateway
       if @path == ''
         "RootResourceId"
       else
-        "#{path_logical_id(@path)}ApiResource"
+        Jets::Resource.truncate_id "#{path_logical_id(@path)}ApiResource"
       end
     end
 
@@ -41,7 +41,7 @@ module Jets::Resource::ApiGateway
       if @path.include?('/') # posts/:id or posts/:id/edit
         parent_path = @path.split('/')[0..-2].join('/')
         parent_logical_id = path_logical_id(parent_path)
-        "!Ref #{parent_logical_id}ApiResource"
+        "!Ref " + Jets::Resource.truncate_id("#{parent_logical_id}ApiResource")
       else
         "!GetAtt #{RestApi.logical_id(@internal)}.RootResourceId"
       end

--- a/spec/lib/jets/controller/callbacks_spec.rb
+++ b/spec/lib/jets/controller/callbacks_spec.rb
@@ -56,6 +56,24 @@ class PrependAppendAfterController < Jets::Controller::Base
   def prepended; end
 end
 
+class SkippedBeforeController < Jets::Controller::Base
+  before_action :first
+  before_action :second
+  skip_before_action :first
+
+  def first; end
+  def second; end
+end
+
+class SkippedAfterController < Jets::Controller::Base
+  after_action :first
+  after_action :second
+  skip_after_action :first
+
+  def first; end
+  def second; end
+end
+
 describe Jets::Controller::Base do
   context FakeController do
     let(:controller) { FakeController.new({}, nil, "meth") }
@@ -94,6 +112,20 @@ describe Jets::Controller::Base do
     subject { PrependAppendAfterController.new({}, nil, :index) }
     it "prepends method" do
       expect(subject.class.after_actions).to eq [[:prepended, {}], [:normal, {}]]
+    end
+  end
+
+  context SkippedBeforeController do
+    subject { SkippedBeforeController.new({}, nil, :index) }
+    it "skips method" do
+      expect(subject.class.before_actions).to eq [[:second, {}]]
+    end
+  end
+
+  context SkippedAfterController do
+    subject { SkippedAfterController.new({}, nil, :index) }
+    it "skips method" do
+      expect(subject.class.after_actions).to eq [[:second, {}]]
     end
   end
 end

--- a/spec/lib/jets/resource/api_gateway/method_spec.rb
+++ b/spec/lib/jets/resource/api_gateway/method_spec.rb
@@ -5,6 +5,7 @@ describe Jets::Resource::ApiGateway::Method do
     let(:route) do
       Jets::Route.new(path: "posts", method: :get, to: "posts#index")
     end
+
     it "resource" do
       expect(resource.logical_id).to eq "PostsIndexGetApiMethod"
       properties = resource.properties
@@ -16,6 +17,26 @@ describe Jets::Resource::ApiGateway::Method do
 
     it 'defaults to no authorization' do
       expect(resource.properties["AuthorizationType"]).to eq 'NONE'
+    end
+  end
+
+  context "long route" do
+    let(:route) do
+      Jets::Route.new(path: "posts/:post_id/comments/:comment_id/images/:images/source_urls/:source_urls", method: :get, to: "posts#index")
+    end
+
+    it "long route" do
+      expect(resource.logical_id).to eq "PostsPostIdCommentsCommentIdImagesImagesSourceUrlsSourceeb106e"
+      expect(resource.logical_id.size).to eq 62
+    end
+
+    it "resource" do
+      expect(resource.logical_id).to eq "PostsPostIdCommentsCommentIdImagesImagesSourceUrlsSourceeb106e"
+      properties = resource.properties
+      # pp properties # uncomment to debug
+      expect(properties["RestApiId"]).to eq "!Ref RestApi"
+      expect(properties["ResourceId"]).to eq "!Ref PostsPostIdCommentsCommentIdImagesImagesSourceUrlsSource9fe958"
+      expect(properties["HttpMethod"]).to eq "GET"
     end
   end
 


### PR DESCRIPTION

This is a 🐞 bug fix.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

This patch limits the API Gateway resource names to 62 characters. Sorry for pushing it so late. Have been delegated to a different project...

## Context

I've seen this pull request: #301 it seems it does something similar for Lambda, not API Gateway. Am I right?

Let me know if you want me to refactor it somehow.