### PR TITLE
Add skip_before_action and skip_after_action method callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project *loosely tries* to adhere to [Semantic Versioning](http://semver.org/).
 
+## [UNRELEASED]
+- Add skip_before_action and skip_after_action callback methods
+
 ## [1.9.28]
 - #302 improve jets call guesser, do a simple detection at the start
 

--- a/lib/jets/controller/callbacks.rb
+++ b/lib/jets/controller/callbacks.rb
@@ -16,6 +16,10 @@ class Jets::Controller
           self.before_actions = [[meth, options]] + self.before_actions
         end
 
+        def skip_before_action(meth)
+          self.before_actions = self.before_actions.reject { |el| el.first.to_s == meth.to_s }
+        end
+
         alias_method :append_before_action, :before_action
 
         def after_action(meth, options={})
@@ -24,6 +28,10 @@ class Jets::Controller
 
         def prepend_after_action(meth, options={})
           self.after_actions = [[meth, options]] + self.after_actions
+        end
+
+        def skip_after_action(meth)
+          self.after_actions = self.after_actions.reject { |el| el.first.to_s == meth.to_s }
         end
 
         alias_method :append_after_action, :after_action

--- a/spec/lib/jets/controller/callbacks_spec.rb
+++ b/spec/lib/jets/controller/callbacks_spec.rb
@@ -56,6 +56,24 @@ class PrependAppendAfterController < Jets::Controller::Base
   def prepended; end
 end
 
+class SkippedBeforeController < Jets::Controller::Base
+  before_action :first
+  before_action :second
+  skip_before_action :first
+
+  def first; end
+  def second; end
+end
+
+class SkippedAfterController < Jets::Controller::Base
+  after_action :first
+  after_action :second
+  skip_after_action :first
+
+  def first; end
+  def second; end
+end
+
 describe Jets::Controller::Base do
   context FakeController do
     let(:controller) { FakeController.new({}, nil, "meth") }
@@ -94,6 +112,20 @@ describe Jets::Controller::Base do
     subject { PrependAppendAfterController.new({}, nil, :index) }
     it "prepends method" do
       expect(subject.class.after_actions).to eq [[:prepended, {}], [:normal, {}]]
+    end
+  end
+
+  context SkippedBeforeController do
+    subject { SkippedBeforeController.new({}, nil, :index) }
+    it "skips method" do
+      expect(subject.class.before_actions).to eq [[:second, {}]]
+    end
+  end
+
+  context SkippedAfterController do
+    subject { SkippedAfterController.new({}, nil, :index) }
+    it "skips method" do
+      expect(subject.class.after_actions).to eq [[:second, {}]]
     end
   end
 end


### PR DESCRIPTION
This is a 🙋‍♂️ feature or enhancement.
- [x] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Added skip_before_action and skip_after_action callbacks to work like in Rails https://apidock.com/rails/v4.0.2/AbstractController/Callbacks/ClassMethods/skip_before_action .