### PR TITLE
allow url paths that contain dashes

### DIFF
--- a/lib/jets/resource/api_gateway/resource.rb
+++ b/lib/jets/resource/api_gateway/resource.rb
@@ -72,7 +72,7 @@ module Jets::Resource::ApiGateway
   private
     # Similar path_logical_id method in resource/route.rb
     def path_logical_id(path)
-      path.gsub('/','_').gsub(':','').gsub('*','').camelize
+      path.gsub('/','_').gsub(':','').gsub('*','').gsub('-','_').camelize
     end
   end
 end

--- a/spec/lib/jets/resource/api_gateway/resource_spec.rb
+++ b/spec/lib/jets/resource/api_gateway/resource_spec.rb
@@ -61,5 +61,17 @@ describe Jets::Resource::ApiGateway::Resource do
       # puts "properties["ParentId" #{properties["ParentId".inspect}"
     end
   end
+
+  context("url with dash") do
+    let(:path) { "url-with-dash" }
+    it "contains info for CloudFormation API Gateway Resources" do
+      expect(resource.logical_id).to eq "UrlWithDashApiResource"
+      properties = resource.properties
+      pp properties
+      expect(properties["PathPart"]).to eq "url-with-dash"
+      expect(properties["ParentId"]).to eq "!GetAtt RestApi.RootResourceId"
+    end
+  end
+
 end
 


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fix this route:

config/routes.rb:

```ruby
Jets.application.routes.draw do
  get "url-with-dash", to: "posts#index"
end
```


## Context

https://community.rubyonjets.com/t/deployment-failing-when-there-is-a-dash-in-a-route-name/211/2

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
