### PR TITLE
Copy .ruby-version file to build directory

### DIFF
--- a/lib/jets/builders/code_builder.rb
+++ b/lib/jets/builders/code_builder.rb
@@ -27,6 +27,7 @@ module Jets::Builders
 
     def build
       check_ruby_version
+      copy_ruby_version_file
       @version_purger.purge
       cache_check_message
 
@@ -368,6 +369,12 @@ module Jets::Builders
         ruby_variant = Jets::RUBY_VERSION.split('.')[0..1].join('.') + '.x'
         abort("Jets uses Ruby #{Jets::RUBY_VERSION}.  You should use a variant of Ruby #{ruby_variant}".color(:red))
       end
+    end
+
+    def copy_ruby_version_file
+      return unless File.exists?(".ruby-version")
+
+      FileUtils.cp_r(Jets.root.join(".ruby-version"), build_area)
     end
 
     def ruby_version_supported?


### PR DESCRIPTION
This is a 🐞 bug fix.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

I did not find any tests related to the `CodeBuilder` class, however, happy to implement if you can point me to it.

## Summary
Copy .ruby-version file to build directory to make sure to use the same ruby version as in the project.

Fix #313

## Context

See #313 for details. We need to use the same ruby version in build directory `/tmp` as in the project directory.

## Version Changes
None