### PR TITLE
fix jets deploy when no /tmp/jets exists yet

### DIFF
--- a/lib/jets/builders/code_builder.rb
+++ b/lib/jets/builders/code_builder.rb
@@ -27,7 +27,6 @@ module Jets::Builders
 
     def build
       check_ruby_version
-      copy_ruby_version_file
       @version_purger.purge
       cache_check_message
 
@@ -35,6 +34,7 @@ module Jets::Builders
       compile_assets # easier to do before we copy the project because node and yarn has been likely setup in the that dir
       compile_rails_assets
       copy_project
+      copy_ruby_version_file
       Dir.chdir("#{stage_area}/code") do
         # These commands run from project root
         code_setup


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

Fix `jets deploy` when `/tmp/jets/PROJECT` does not yet exist on the first deploy.

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

Related: #316

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
