### PR TITLE
Import custom rake tasks

### DIFF
--- a/lib/jets/commands/rake_tasks.rb
+++ b/lib/jets/commands/rake_tasks.rb
@@ -18,7 +18,7 @@ class Jets::Commands::RakeTasks
       load_webpacker_tasks
 
       # custom project rake tasks
-      Dir.glob("#{Jets.root}/lib/tasks/*.rake").each { |r| load r }
+      Dir.glob("#{Jets.root}/lib/tasks/*.rake").each { |r| import r }
 
       @@loaded = true
     end


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Loading custom rake tasks via `import` 

## Context

As of jets 2.0.0, custom tasks do no load automatically. This update should fix the issue. 

## Version Changes

Patch: x.x.+