### PR TITLE
fix remove Rails const

### DIFF
--- a/docs/_reference/jets-degenerate.md
+++ b/docs/_reference/jets-degenerate.md
@@ -9,36 +9,7 @@ reference: true
 
 ## Description
 
-Destroys things like scaffolds.
-
-This piggy backs off of the [jets scaffold generator](https://guides.rubyonjets.org/command_line.html#jets-generate).
-
-## General options
-
-    -h, [--help]     # Print generator's options and usage
-    -p, [--pretend]  # Run but do not make any changes
-    -f, [--force]    # Overwrite files that already exist
-    -s, [--skip]     # Skip files that already exist
-    -q, [--quiet]    # Suppress status output
-
-Please choose a generator below.
-
-Jets:
-
-    application_record
-    controller
-    helper
-    job
-    migration
-    model
-    resource
-    scaffold
-    scaffold_controller
-    task
-
-ActiveRecord:
-
-    active_record:application_record
+Destroys things like scaffolds
 
 ## Options
 

--- a/docs/_reference/jets-degenerate.md
+++ b/docs/_reference/jets-degenerate.md
@@ -9,7 +9,36 @@ reference: true
 
 ## Description
 
-Destroys things like scaffolds
+Destroys things like scaffolds.
+
+This piggy backs off of the [rails scaffold generator](https://guides.rubyonrails.org/command_line.html#rails-generate).
+
+## General options
+
+    -h, [--help]     # Print generator's options and usage
+    -p, [--pretend]  # Run but do not make any changes
+    -f, [--force]    # Overwrite files that already exist
+    -s, [--skip]     # Skip files that already exist
+    -q, [--quiet]    # Suppress status output
+
+Please choose a generator below.
+
+Jets:
+
+    application_record
+    controller
+    helper
+    job
+    migration
+    model
+    resource
+    scaffold
+    scaffold_controller
+    task
+
+ActiveRecord:
+
+    active_record:application_record
 
 ## Options
 

--- a/docs/_reference/jets-generate.md
+++ b/docs/_reference/jets-generate.md
@@ -9,7 +9,36 @@ reference: true
 
 ## Description
 
-Generates things like scaffolds
+Generates things like scaffolds.
+
+This piggy backs off of the [rails scaffold generator](https://guides.rubyonrails.org/command_line.html#rails-generate).
+
+## General options
+
+    -h, [--help]     # Print generator's options and usage
+    -p, [--pretend]  # Run but do not make any changes
+    -f, [--force]    # Overwrite files that already exist
+    -s, [--skip]     # Skip files that already exist
+    -q, [--quiet]    # Suppress status output
+
+Please choose a generator below.
+
+Jets:
+
+    application_record
+    controller
+    helper
+    job
+    migration
+    model
+    resource
+    scaffold
+    scaffold_controller
+    task
+
+ActiveRecord:
+
+    active_record:application_record
 
 ## Options
 

--- a/docs/_reference/jets-generate.md
+++ b/docs/_reference/jets-generate.md
@@ -9,36 +9,7 @@ reference: true
 
 ## Description
 
-Generates things like scaffolds.
-
-This piggy backs off of the [jets scaffold generator](https://guides.rubyonjets.org/command_line.html#jets-generate).
-
-## General options
-
-    -h, [--help]     # Print generator's options and usage
-    -p, [--pretend]  # Run but do not make any changes
-    -f, [--force]    # Overwrite files that already exist
-    -s, [--skip]     # Skip files that already exist
-    -q, [--quiet]    # Suppress status output
-
-Please choose a generator below.
-
-Jets:
-
-    application_record
-    controller
-    helper
-    job
-    migration
-    model
-    resource
-    scaffold
-    scaffold_controller
-    task
-
-ActiveRecord:
-
-    active_record:application_record
+Generates things like scaffolds
 
 ## Options
 

--- a/lib/jets/cli.rb
+++ b/lib/jets/cli.rb
@@ -80,7 +80,8 @@ class Jets::CLI
     # `jets generate` is called without additional args.  We'll take it over early and fix it here.
     autocomplete_command = Jets::Commands::Base.autocomplete(args[0])
     generate = autocomplete_command == "generate"
-    if generate && (args.size == 1 || help_flags.include?(args.last))
+
+    if generate && ((args.size == 1 || help_flags.include?(args.last)) || args.size == 2)
       puts Jets::Generator.help
       exit
     end

--- a/lib/jets/commands/main.rb
+++ b/lib/jets/commands/main.rb
@@ -97,13 +97,13 @@ module Jets::Commands
     end
 
     desc "generate [type] [args]", "Generates things like scaffolds"
-    long_desc Jets::Generator.help
+    # no long_desc because its handled higher up in cli.rb by thor_args override
     def generate(generator, *args)
       Jets::Generator.invoke(generator, *args)
     end
 
     desc "degenerate [type] [args]", "Destroys things like scaffolds"
-    long_desc Jets::Generator.help
+    # no long_desc because its handled higher up in cli.rb by thor_args override
     def degenerate(generator, *args)
       Jets::Generator.revoke(generator, *args)
     end

--- a/lib/jets/commands/main.rb
+++ b/lib/jets/commands/main.rb
@@ -97,13 +97,13 @@ module Jets::Commands
     end
 
     desc "generate [type] [args]", "Generates things like scaffolds"
-    # no long_desc because its handled higher up in cli.rb by thor_args override
+    long_desc Help.text(:generate) # do use Jets::Generator.help as it'll load Rails const
     def generate(generator, *args)
       Jets::Generator.invoke(generator, *args)
     end
 
     desc "degenerate [type] [args]", "Destroys things like scaffolds"
-    # no long_desc because its handled higher up in cli.rb by thor_args override
+    long_desc Help.text(:generate) # do use Jets::Generator.help as it'll load Rails const
     def degenerate(generator, *args)
       Jets::Generator.revoke(generator, *args)
     end

--- a/lib/jets/generator.rb
+++ b/lib/jets/generator.rb
@@ -10,8 +10,6 @@ class Jets::Generator
     end
 
     def help(args=ARGV)
-      require_generators
-
       # `jets generate -h` results in:
       #
       #     args = ["generate", "-h"]


### PR DESCRIPTION
* also improve `jets generate scaffold` help menu to not require `-h` flag

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Rails const was accidentally reintroduced in v2. This removes it again. 

## Context

https://community.rubyonjets.com/t/why-does-jets-define-rails-module/29/6

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
