### PR TITLE
spec helpers: include routes helper

### DIFF
--- a/lib/jets/spec_helpers/controllers.rb
+++ b/lib/jets/spec_helpers/controllers.rb
@@ -1,5 +1,7 @@
 module Jets::SpecHelpers
   module Controllers
+    include Jets::Router::Helpers # must be at the top because response is overridden later
+
     attr_reader :request, :response
 
     def initialize(*)


### PR DESCRIPTION
This is a 🙋‍♂️ feature or enhancement.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Adds routes helpers for the spec helpers for controllers.  

## Context

* #308 Mentioned here
* https://community.rubyonjets.com/t/advanced-routes/77/9
