### PR TITLE
Always keep vendor directory

### DIFF
--- a/lib/jets/builders/tidy.rb
+++ b/lib/jets/builders/tidy.rb
@@ -55,7 +55,7 @@ module Jets::Builders
     # We clean out ignored files pretty aggressively. So provide
     # a way for users to keep files from being cleaned out.
     def jetskeep
-      always = %w[.bundle packs]
+      always = %w[.bundle packs vendor]
       path = "#{@project_root}/.jetskeep"
       return always unless File.exist?(path)
 


### PR DESCRIPTION
This is a 🐞 bug fix.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

It is quite common in Ruby to add `vendor` directory to `.gitignore` to not add dependencies to version control. However, Jets aggressively removes everything from `.gitignore`. I think we should keep the `vendor` directory as there is a dedicated step `clean_vendor_gems` already.

If `vendor` is in `.gitignore` file, the deployment will fail because `rsync` of the gem directory will fail.
