### PR TITLE
Controller action_name method

### DIFF
--- a/lib/jets/controller/base.rb
+++ b/lib/jets/controller/base.rb
@@ -97,6 +97,10 @@ class Jets::Controller
       paths
     end
 
+    def action_name
+      @meth
+    end 
+
     def self.controller_path
       name.sub(/Controller$/, "".freeze).underscore
     end


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

In rails controller, the `action_name` method gives you access of current action being called. 


## Context

This is needed when using other gems that rely on this information. I've added to my base controller and it is working but adding it here will give us all the benefit.

Currently the router uses `controller.action_name` and passes that to base controller as `meth`. 

## Version Changes

x.x.+