### PR TITLE
Escape paths passed to rsync

### DIFF
--- a/lib/jets/util.rb
+++ b/lib/jets/util.rb
@@ -1,3 +1,5 @@
+require 'shellwords'
+
 class Jets::Util
   class << self
     # Make sure that the result is a text.
@@ -14,7 +16,7 @@ class Jets::Util
       src.chop! if src.ends_with?('/')
       dest.chop! if dest.ends_with?('/')
       check_rsync_installed!
-      sh "rsync -a --links --no-specials --no-devices #{src}/ #{dest}/", quiet: true
+      sh "rsync -a --links --no-specials --no-devices #{Shellwords.escape(src)}/ #{Shellwords.escape(dest)}/", quiet: true
     end
 
     @@rsync_installed = false


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [X] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

This is a small change to properly escape paths passed directly to rsync on the command line in case the path contains special characters. 

## Context

The volume on my MacBook Pro has a space in the name, which broke jets when trying to run `jets deploy`. This fixed the issue. Shellwords is available on all Rubies since, I believe, 1.9.x. 

NOTE: I didn't add a test, I'm not sure how to effectively test for this, or if it is worthwhile. I'd appreciate guidance on the tests you'd like, if any. 

## Version Changes

Recommended for a 