### PR TITLE
Support for "apiKeyRequired" option for API method #334

### DIFF
--- a/lib/jets/application/defaults.rb
+++ b/lib/jets/application/defaults.rb
@@ -99,6 +99,7 @@ class Jets::Application
       config.api.cors_authorization_type = nil # nil so ApiGateway::Cors#cors_authorization_type handles
       config.api.binary_media_types = ['multipart/form-data']
       config.api.endpoint_type = 'EDGE' # PRIVATE, EDGE, REGIONAL
+      config.api.api_key_required = false # Turn off API key required
 
       config.domain = ActiveSupport::OrderedOptions.new
       # config.domain.name = "#{Jets.project_namespace}.coolapp.com" # Default is nil

--- a/lib/jets/controller/base.rb
+++ b/lib/jets/controller/base.rb
@@ -99,7 +99,7 @@ class Jets::Controller
 
     def action_name
       @meth
-    end 
+    end
 
     def self.controller_path
       name.sub(/Controller$/, "".freeze).underscore
@@ -129,6 +129,15 @@ class Jets::Controller
         self.auth_type = value
       else
         self.auth_type
+      end
+    end
+
+    class_attribute :api_key_needed
+    def self.api_key_required(value=nil)
+      if !value.nil?
+        self.api_key_needed = value
+      else
+        self.api_key_needed
       end
     end
   end

--- a/lib/jets/resource/api_gateway/method.rb
+++ b/lib/jets/resource/api_gateway/method.rb
@@ -20,7 +20,7 @@ module Jets::Resource::ApiGateway
             http_method: @route.method,
             request_parameters: {},
             authorization_type: authorization_type,
-            api_key_required: api_key_required,
+            api_key_required: api_key_required?,
             integration: {
               integration_http_method: "POST",
               type: "AWS_PROXY",
@@ -75,6 +75,10 @@ module Jets::Resource::ApiGateway
     def controller_auth_type
       # Already handles inheritance via class_attribute
       controller_klass.authorization_type
+    end
+
+    def api_key_required?
+      api_key_required == true
     end
 
     def api_key_required

--- a/lib/jets/resource/api_gateway/method.rb
+++ b/lib/jets/resource/api_gateway/method.rb
@@ -20,6 +20,7 @@ module Jets::Resource::ApiGateway
             http_method: @route.method,
             request_parameters: {},
             authorization_type: authorization_type,
+            api_key_required: api_key_required,
             integration: {
               integration_http_method: "POST",
               type: "AWS_PROXY",
@@ -72,10 +73,22 @@ module Jets::Resource::ApiGateway
     end
 
     def controller_auth_type
-      controller_name = @route.to.split('#').first
-      controller = "#{controller_name}_controller".camelize.constantize
       # Already handles inheritance via class_attribute
-      controller.authorization_type
+      controller_klass.authorization_type
+    end
+
+    def api_key_required
+      @route.api_key_required ||
+        controller_klass.api_key_required ||
+        Jets.config.api.api_key_required
+    end
+
+    def controller_klass
+      @controller_klass ||= "#{controller_name}_controller".camelize.constantize
+    end
+
+    def controller_name
+      @controller_name ||= @route.to.split('#').first
     end
 
     def resource_id

--- a/lib/jets/router/route.rb
+++ b/lib/jets/router/route.rb
@@ -187,6 +187,10 @@ class Jets::Router
       @options[:authorization_type]
     end
 
+    def api_key_required
+      @options[:api_key_required]
+    end
+
   private
     def ensure_jets_format(path)
       path.split('/').map do |s|

--- a/spec/lib/jets/resource/api_gateway/method_spec.rb
+++ b/spec/lib/jets/resource/api_gateway/method_spec.rb
@@ -18,6 +18,10 @@ describe Jets::Resource::ApiGateway::Method do
     it 'defaults to no authorization' do
       expect(resource.properties["AuthorizationType"]).to eq 'NONE'
     end
+
+    it 'defaults to no api_key_required' do
+      expect(resource.properties["ApiKeyRequired"]).to eq ''
+    end
   end
 
   context "long route" do
@@ -46,6 +50,16 @@ describe Jets::Resource::ApiGateway::Method do
     end
     it "can specify an authorization type" do
       expect(resource.properties["AuthorizationType"]).to eq 'AWS_IAM'
+    end
+  end
+
+  context "api key" do
+    let(:route) do
+      Jets::Router::Route.new(path: "posts", method: :get, to: "posts#index", api_key_required: true)
+    end
+
+    it "can specify an api_key_required" do
+      expect(resource.properties["ApiKeyRequired"]).to eq 'true'
     end
   end
 end

--- a/spec/lib/jets/resource/api_gateway/method_spec.rb
+++ b/spec/lib/jets/resource/api_gateway/method_spec.rb
@@ -20,7 +20,7 @@ describe Jets::Resource::ApiGateway::Method do
     end
 
     it 'defaults to no api_key_required' do
-      expect(resource.properties["ApiKeyRequired"]).to eq ''
+      expect(resource.properties["ApiKeyRequired"]).to eq 'false'
     end
   end
 
@@ -63,4 +63,3 @@ describe Jets::Resource::ApiGateway::Method do
     end
   end
 end
-


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🙋‍♂️ feature or enhancement.

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [x ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

AWS API Gateway has build-in support for API Keys. More info here
https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html
This pull request allows configuring API methods to enable this feature.
You can configure the feature at different levels:
Application level:
```
# config/application.rb
Jets.application.configure do
  config.api.api_key_required = true
end
``` 

Controller level:
```
# app/controllers/posts_controller.rb
class PostsController < ApplicationController
  api_key_required true
end
``` 

Route level:
```
# config/routes.rb
Jets.application.routes.draw do
  get  "posts", to: "posts#index", api_key_required: true
end
```

## Context

https://github.com/tongueroo/jets/issues/334

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
