### PR TITLE
Implement endpoint_policy configuration

### DIFF
--- a/docs/_docs/app-config.md
+++ b/docs/_docs/app-config.md
@@ -37,7 +37,8 @@ Jets.application.configure do
 
   # config.api.authorization_type = "AWS_IAM" # default is 'NONE' https://amzn.to/2qZ7zLh
   # config.api.binary_media_types = ['multipart/form-data'] # default is ['multipart/form-data'] # Changing this will update the API Gateway DNS
-  # config.api.endpoint_type = 'PRIVATE' # Default is 'EDGE' https://amzn.to/2r0Iu2L
+  # config.api.endpoint_type = 'PRIVATE' # Default is 'EDGE' https://amzn.to/2r0Iu2L, you need to set an endpoint_policy if this is 'PRIVATE'
+  # config.api.endpoint_policy = {} # Default is nil https://amzn.to/2r0Iu2L
 end
 ```
 

--- a/lib/jets/application/defaults.rb
+++ b/lib/jets/application/defaults.rb
@@ -99,6 +99,7 @@ class Jets::Application
       config.api.cors_authorization_type = nil # nil so ApiGateway::Cors#cors_authorization_type handles
       config.api.binary_media_types = ['multipart/form-data']
       config.api.endpoint_type = 'EDGE' # PRIVATE, EDGE, REGIONAL
+      config.api.endpoint_policy = nil
 
       config.domain = ActiveSupport::OrderedOptions.new
       # config.domain.name = "#{Jets.project_namespace}.coolapp.com" # Default is nil

--- a/lib/jets/resource/api_gateway/rest_api.rb
+++ b/lib/jets/resource/api_gateway/rest_api.rb
@@ -6,6 +6,7 @@ module Jets::Resource::ApiGateway
         endpoint_configuration: { types: endpoint_types }
       }
       properties[:binary_media_types] = binary_media_types if binary_media_types
+      properties[:policy] = endpoint_policy if endpoint_policy
 
       {
         internal_logical_id => {
@@ -51,6 +52,13 @@ module Jets::Resource::ApiGateway
       return nil if types.nil? || types.empty?
 
       [types].flatten
+    end
+
+    def endpoint_policy
+      endpoint_policy = Jets.config.api.endpoint_policy
+      return nil if endpoint_policy.nil? || endpoint_policy.empty?
+
+      endpoint_policy
     end
   end
 end

--- a/spec/lib/jets/resource/api_gateway/rest_api_spec.rb
+++ b/spec/lib/jets/resource/api_gateway/rest_api_spec.rb
@@ -16,4 +16,18 @@ describe Jets::Resource::ApiGateway::RestApi do
     end
   end
 
+  context "policy configuration" do
+    let(:endpoint_policy) do
+      Jets::Resource::ApiGateway::RestApi.new.properties["Policy"]
+    end
+
+    it 'defaults to nil' do
+      expect(endpoint_policy).to be_nil
+    end
+
+    it 'can be set explicitly' do
+      allow(Jets.config.api).to receive(:endpoint_policy).and_return(version: "2012-10-17")
+      expect(endpoint_policy).to a_hash_including("Version" => "2012-10-17")
+    end
+  end
 end


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.


- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Deploying with `config.api.endpoint_type = 'PRIVATE'` fails in CloudFormation because Private REST API doesn't have a resource policy attached to it.

> Service: AmazonApiGateway; Status Code: 400; Error Code: BadRequestException; Request ID: **********)

This PR implements an `config.api.endpoint_policy` configuration.

See https://community.rubyonjets.com/t/how-do-i-apply-a-resource-policy-to-a-private-api-gateway-deploy/241/2


