### PR TITLE
Fix tidy_spec

### DIFF
--- a/spec/lib/jets/builders/tidy_spec.rb
+++ b/spec/lib/jets/builders/tidy_spec.rb
@@ -11,7 +11,7 @@ describe Jets::Builders::Tidy do
       end
 
       it "excludes should not include jetskeep" do
-        expect(tidy.jetskeep).to eq [".bundle", "packs", "pack"]
+        expect(tidy.jetskeep).to eq [".bundle", "packs", "vendor", "pack"]
       end
     end
   end


### PR DESCRIPTION
This is a 🐞 bug fix.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

The test broke with aae2d16b3801d83d78675ad526da2448a409667c
