### PR TITLE
Return exist status 1 if deployment fails

### DIFF
--- a/lib/jets/cfn/ship.rb
+++ b/lib/jets/cfn/ship.rb
@@ -40,7 +40,7 @@ module Jets::Cfn
           The specific child stack usually shows more detailed information and can be used to resolve the issue.
           Example of checking the CloudFormation console: https://rubyonjets.com/docs/debugging/cloudformation/
         EOL
-        return
+        exit 1
       end
 
       prewarm


### PR DESCRIPTION

This is a 🐞 bug fix.


- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Because it is not a success so we shouldn't return exit status 0. This is especially important for CI to stop additional steps (e.g. deploy production after deploying staging)

