### PR TITLE
Skip before action options

### DIFF
--- a/docs/_docs/extras/action-filters.md
+++ b/docs/_docs/extras/action-filters.md
@@ -36,4 +36,26 @@ private
 end
 ```
 
+## Example skip_before_action
+
+```ruby
+class ApplicationController < Jets::Controller::Base
+  before_action :authenticate_user_session
+
+  # ...
+
+
+class PublicDocumentsController < ApplicationController
+  # skip the authenticate_user_session for all the methods in the controller
+  skip_before_action :authenticate_user_session
+
+  # ...
+
+class PostsController < ApplicationController
+  # skip the authenticate_user_session only for the index method in the controller
+  skip_before_action :authenticate_user_session, only: [:index]
+
+
+```
+
 {% include prev_next.md %}

--- a/lib/jets/controller/callbacks.rb
+++ b/lib/jets/controller/callbacks.rb
@@ -16,8 +16,11 @@ class Jets::Controller
           self.before_actions = [[meth, options]] + self.before_actions
         end
 
-        def skip_before_action(meth)
-          self.before_actions = self.before_actions.reject { |el| el.first.to_s == meth.to_s }
+        def skip_before_action(meth, options = {})
+          # adds the methods in the only to the exception list for the callback
+          return append_except_to_callbacks(self.before_actions, meth, options[:only]) if options[:only].present?
+            
+          self.before_actions.reject! { |el| el.first.to_s == meth.to_s }
         end
 
         alias_method :append_before_action, :before_action
@@ -35,6 +38,20 @@ class Jets::Controller
         end
 
         alias_method :append_after_action, :after_action
+
+        private
+
+        def append_except_to_callbacks(callback_methods, meth, excepted_methods)
+          callback_methods.map! do |callback_method|
+            if callback_method.first.to_s == meth.to_s
+              exceptions = callback_method.second[:except] || []
+              exceptions.concat(Array.wrap(excepted_methods))
+              callback_method.second[:except] = exceptions
+            end
+
+            callback_method
+          end
+        end
       end
     end # included
 

--- a/lib/jets/controller/callbacks.rb
+++ b/lib/jets/controller/callbacks.rb
@@ -8,11 +8,11 @@ class Jets::Controller
       class_attribute :after_actions, default: []
 
       class << self
-        def before_action(meth, options={})
+        def before_action(meth, options = {})
           self.before_actions += [[meth, options]]
         end
 
-        def prepend_before_action(meth, options={})
+        def prepend_before_action(meth, options = {})
           self.before_actions = [[meth, options]] + self.before_actions
         end
 
@@ -22,11 +22,11 @@ class Jets::Controller
 
         alias_method :append_before_action, :before_action
 
-        def after_action(meth, options={})
+        def after_action(meth, options = {})
           self.after_actions += [[meth, options]]
         end
 
-        def prepend_after_action(meth, options={})
+        def prepend_after_action(meth, options = {})
           self.after_actions = [[meth, options]] + self.after_actions
         end
 

--- a/spec/lib/jets/controller/callbacks_spec.rb
+++ b/spec/lib/jets/controller/callbacks_spec.rb
@@ -65,12 +65,12 @@ class SkippedBeforeController < Jets::Controller::Base
   def second; end
 end
 
-class SkippedBeforeControllerWithOnly < Jets::Controller::Base
+class SkippedBeforeWithOnlyController < Jets::Controller::Base
   before_action :first
-  skip_before_action :first, only: %i[second]
+  skip_before_action :first, only: %i[index]
 
   def first; end
-  def second; end
+  def index; end
 end
 
 
@@ -131,10 +131,10 @@ describe Jets::Controller::Base do
     end
   end
 
-  context SkippedBeforeControllerWithOnly do
-    subject { SkippedBeforeControllerWithOnly.new({}, nil, :index) }
+  context SkippedBeforeWithOnlyController do
+    subject { SkippedBeforeWithOnlyController.new({}, nil, :index) }
     it "adds the method to the except of the callback" do
-      expect(subject.class.before_actions).to eq [[:first, {except: [:second]}]]
+      expect(subject.class.before_actions).to eq [[:first, {except: [:index]}]]
     end
   end
 

--- a/spec/lib/jets/controller/callbacks_spec.rb
+++ b/spec/lib/jets/controller/callbacks_spec.rb
@@ -65,6 +65,15 @@ class SkippedBeforeController < Jets::Controller::Base
   def second; end
 end
 
+class SkippedBeforeControllerWithOnly < Jets::Controller::Base
+  before_action :first
+  skip_before_action :first, only: %i[second]
+
+  def first; end
+  def second; end
+end
+
+
 class SkippedAfterController < Jets::Controller::Base
   after_action :first
   after_action :second
@@ -119,6 +128,13 @@ describe Jets::Controller::Base do
     subject { SkippedBeforeController.new({}, nil, :index) }
     it "skips method" do
       expect(subject.class.before_actions).to eq [[:second, {}]]
+    end
+  end
+
+  context SkippedBeforeControllerWithOnly do
+    subject { SkippedBeforeControllerWithOnly.new({}, nil, :index) }
+    it "adds the method to the except of the callback" do
+      expect(subject.class.before_actions).to eq [[:first, {except: [:second]}]]
     end
   end
 


### PR DESCRIPTION
This is a 🙋‍♂️ feature or enhancement. 

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes

## Summary

Adding capability to define `only` option in the skip_before_action method; by adding the method(s) in the `only` list to the action's except list.

## Context

Have global actions defined in the controller's base, but allow the children controllers to be able to skip that action to certain methods only;

example above has the ApplicationController with a before_action that ensures the user to be logged in. 

and the PostController that also extends the action; but allows only one of its method to skip the `authenticate_user`. other methods in the PostController are still being protected by `authenticate_user`

```ruby
class ApplicationController < Jets::Controller::Base
  before_action :authenticate_user

  # ...

class PostController < ApplicationController
  skip_before_action :authenticate_user, only: [:view_public_fee]

```
