### PR TITLE
spec helpers: dont cache requeset headers between specs

### DIFF
--- a/lib/jets/spec_helpers/controllers.rb
+++ b/lib/jets/spec_helpers/controllers.rb
@@ -2,12 +2,11 @@ module Jets::SpecHelpers
   module Controllers
     include Jets::Router::Helpers # must be at the top because response is overridden later
 
-    attr_reader :request, :response
-
-    def initialize(*)
-      super
-      @request = Request.new(:get, '/', {}, Params.new)
-      @response = nil # will be set after http_call
+    attr_reader :response
+    # Note: caching it like this instead of within the initialize results in the headers not being cached
+    # See: https://community.rubyonjets.com/t/is-jets-spechelpers-controllers-request-being-cached/244/2
+    def request
+      @request ||= Request.new(:get, '/', {}, Params.new)
     end
 
     rest_methods = %w[get post put patch delete]


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Bug: Request headers are cached between specs. 

## Context

https://community.rubyonjets.com/t/is-jets-spechelpers-controllers-request-being-cached/244/2## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
