### PR TITLE
upgrade to use rails 6 components

### DIFF
--- a/docs/_docs/crud-html-activerecord.md
+++ b/docs/_docs/crud-html-activerecord.md
@@ -72,7 +72,7 @@ In the next step, we'll update the .env.development and set the local database c
 ```yaml
 default: &default
   adapter: postgresql
-  encoding: utf8
+  encoding: utf8mb4
   pool: <%= ENV["DB_POOL"] || 5  %>
   database: <%= ENV['DB_NAME'] || 'demo_dev' %>
   username: <%= ENV['DB_USER'] || ENV['USER'] %>

--- a/docs/_docs/crud-json-activerecord.md
+++ b/docs/_docs/crud-json-activerecord.md
@@ -66,7 +66,7 @@ In the next step, we'll update the .env.development and set the local database c
 ```yaml
 default: &default
   adapter: postgresql
-  encoding: utf8
+  encoding: utf8mb4
   pool: <%= ENV["DB_POOL"] || 5  %>
   database: <%= ENV['DB_NAME'] || 'demo_dev' %>
   username: <%= ENV['DB_USER'] || ENV['USER'] %>

--- a/jets.gemspec
+++ b/jets.gemspec
@@ -27,11 +27,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "actionmailer", "~> 5.2.1"
-  spec.add_dependency "actionpack", "~> 5.2.1"
-  spec.add_dependency "actionview", "~> 5.2.1"
-  spec.add_dependency "activerecord", "~> 5.2.1"
-  spec.add_dependency "activesupport", "~> 5.2.1"
+  spec.add_dependency "actionmailer", "~> 6.0.0"
+  spec.add_dependency "actionpack", "~> 6.0.0"
+  spec.add_dependency "actionview", "~> 6.0.0"
+  spec.add_dependency "activerecord", "~> 6.0.0"
+  spec.add_dependency "activesupport", "~> 6.0.0"
   spec.add_dependency "aws-sdk-apigateway"
   spec.add_dependency "aws-sdk-cloudformation"
   spec.add_dependency "aws-sdk-cloudwatchlogs"
@@ -53,7 +53,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "memoist"
   spec.add_dependency "mimemagic"
   spec.add_dependency "rack"
-  spec.add_dependency "railties", "~> 5.2.1" # ActiveRecord database_tasks.rb require this
+  spec.add_dependency "railties", "~> 6.0.0" # for ActiveRecord database_tasks.rb
   spec.add_dependency "rainbow"
   spec.add_dependency "recursive-open-struct"
   spec.add_dependency "shotgun"

--- a/lib/jets/application.rb
+++ b/lib/jets/application.rb
@@ -175,15 +175,16 @@ class Jets::Application
     end
   end
 
-  def load_db_config
+  def load_db_config(database_yml="#{Jets.root}/config/database.yml")
     config.database = {}
 
     Jets::Dotenv.load!
-    database_yml = "#{Jets.root}/config/database.yml"
     if File.exist?(database_yml)
+      require "active_record/database_configurations" # lazy require
       text = Jets::Erb.result(database_yml)
-      db_config = YAML.load(text)
-      config.database = db_config
+      db_configs = YAML.load(text)
+      configurations = ActiveRecord::DatabaseConfigurations.new(db_configs)
+      config.database = configurations
     end
   end
 

--- a/lib/jets/booter.rb
+++ b/lib/jets/booter.rb
@@ -23,14 +23,46 @@ class Jets::Booter
       run_turbines(:after_initializers)
       Jets.application.finish!
 
-      # Eager load project code. Rather have user find out early than later on AWS Lambda.
-      Jets::Autoloaders.main.eager_load
+      setup_db # establish db connections in Lambda Execution Context.
+      # The eager load calls connects_to in models and establish those connections in Lambda Execution Context also.
+      Jets::Autoloaders.main.eager_load # Eager load project code. Rather have user find out early than later on AWS Lambda.
 
-      setup_db
       # TODO: Figure out how to build middleware during Jets.boot without breaking jets new and webpacker:install
       # build_middleware_stack
 
       @booted = true
+    end
+
+    # Using ActiveRecord outside of Rails, so we need to set up the db connection ourself.
+    #
+    # Only connects to database for ActiveRecord and when config/database.yml exists.
+    # Dynomite handles connecting to the clients lazily.
+    def setup_db
+      return unless File.exist?("#{Jets.root}/config/database.yml")
+
+      db_configs = Jets.application.config.database
+      # DatabaseTasks.database_configuration for db:create db:migrate tasks
+      # Documented in DatabaseTasks that this is the right way to set it when
+      # using ActiveRecord rake tasks outside of Rails.
+      ActiveRecord::Tasks::DatabaseTasks.database_configuration = db_configs
+
+      if db_configs[Jets.env].blank?
+        abort("ERROR: config/database.yml exists but no environment section configured for #{Jets.env}")
+      end
+      ActiveRecord::Base.configurations = db_configs
+      connect_db
+    end
+
+    # Eager connect to database, so connections are established in the Lambda Execution Context and get reused.
+    # Interestingly, the connections info is stored in the shared state but the connection doesnt show up on
+    # `show processlist` until after a query. Have confirmed that the connection is reused and the connection count stays
+    # the same.
+    def connect_db
+      primary_hash_config = ActiveRecord::Base.configurations.configs_for(env_name: Jets.env).find { |hash_config|
+        hash_config.spec_name == "primary"
+      }
+      primary_config = primary_hash_config.config # config is a normal Ruby Hash
+      ActiveRecord::Base.establish_connection(primary_config)
     end
 
     def load_internal_turbines
@@ -70,27 +102,6 @@ class Jets::Booter
     # Builds and memoize stack so it only gets built on bootup
     def build_middleware_stack
       Jets.application.build_stack
-    end
-
-    # Only connects connect to database for ActiveRecord and when
-    # config/database.yml exists.
-    # Dynomite handles connecting to the clients lazily.
-    def setup_db
-      return unless File.exist?("#{Jets.root}/config/database.yml")
-
-      db_configs = Jets.application.config.database
-      # DatabaseTasks.database_configuration for db:create db:migrate tasks
-      # Documented in DatabaseTasks that this is the right way to set it when
-      # using ActiveRecord rake tasks outside of Rails.
-      ActiveRecord::Tasks::DatabaseTasks.database_configuration = db_configs
-
-      current_config = db_configs[Jets.env]
-      if current_config.blank?
-        abort("ERROR: config/database.yml exists but no environment section configured for #{Jets.env}")
-      end
-      # Using ActiveRecord rake tasks outside of Rails, so we need to set up the
-      # db connection ourselves
-      ActiveRecord::Base.establish_connection(current_config)
     end
 
     # Cannot call this for the jets new

--- a/lib/jets/commands/db/tasks.rb
+++ b/lib/jets/commands/db/tasks.rb
@@ -4,7 +4,6 @@ class Jets::Commands::Db::Tasks
     # Lazy require rails so Rails const is only defined in jets db:* tasks
     require "rails"
     require "active_record"
-    require "recursive-open-struct"
 
     # Jets.boot # Jets.boot here screws up jets -h, the db_config doesnt seem to match exactly
     # but seems to be working anyway.
@@ -15,20 +14,11 @@ class Jets::Commands::Db::Tasks
 
     # Need to mock out the usage of Rails.application in:
     # activerecord-5.1.4/lib/active_record/tasks/database_tasks.rb
-    Rails.application = RecursiveOpenStruct.new(
-      config: {
-        paths: {
-          db: ["db"],
-        }
-      },
-      paths: {
-        "db/migrate": ["db/migrate"]
-      }
-    )
+    Rails.application = Dummy::App.new
     load "active_record/railties/databases.rake"
-
     load File.expand_path("../environment-task.rake", __FILE__)
   end
+
 
   # Thanks: https://stackoverflow.com/questions/19206764/how-can-i-load-activerecord-database-tasks-on-a-ruby-project-outside-rails/24840749
   class Seeder

--- a/lib/jets/commands/db/tasks/dummy/app.rb
+++ b/lib/jets/commands/db/tasks/dummy/app.rb
@@ -1,0 +1,21 @@
+require "recursive-open-struct"
+
+module Jets::Commands::Db::Tasks::Dummy
+  class App
+    def config
+      Config.new(
+        paths: {
+          db: ["db"],
+        }
+      )
+    end
+
+    def paths
+      RecursiveOpenStruct.new(
+        paths: {
+          "db/migrate": ["db/migrate"]
+        }
+      )
+    end
+  end
+end

--- a/lib/jets/commands/db/tasks/dummy/config.rb
+++ b/lib/jets/commands/db/tasks/dummy/config.rb
@@ -1,0 +1,14 @@
+require "recursive-open-struct"
+
+module Jets::Commands::Db::Tasks::Dummy
+  class Config < RecursiveOpenStruct
+    def load_database_yaml # :nodoc:
+      require "rails/application/dummy_erb_compiler"
+
+      path = "#{Jets.root}/config/database.yml"
+      yaml = Pathname.new(path)
+      erb = DummyERB.new(yaml.read)
+      YAML.load(erb.result) || {}
+    end
+  end
+end

--- a/lib/jets/commands/import/templates/config/database.yml
+++ b/lib/jets/commands/import/templates/config/database.yml
@@ -1,6 +1,6 @@
 default: &default
   adapter:  <%= @adapter %>
-  encoding: utf8
+  encoding: utf8mb4
   pool: <%%= ENV["DB_POOL"] || 5  %>
   database: <%%= ENV['DB_NAME'] || '<%= @database_development %>' %>
 <% if @adapter == 'postgresql' -%>

--- a/lib/jets/commands/templates/skeleton/config/database.yml.tt
+++ b/lib/jets/commands/templates/skeleton/config/database.yml.tt
@@ -1,9 +1,10 @@
 default: &default
   adapter: <%= @database == 'mysql' ? 'mysql2' : 'postgresql' %>
-  encoding: utf8
+  encoding: utf8mb4
   pool: <%%= ENV["DB_POOL"] || 5  %>
   database: <%%= ENV['DB_NAME'] || '<%= @project_name %>_development' %>
 <% if @database == 'mysql' -%>
+  encoding: utf8mb4
   username: <%%= ENV['DB_USER'] || 'root' %>
 <% else -%>
   username: <%%= ENV['DB_USER'] || ENV['USER'] %>

--- a/lib/jets/turbo/templates/config/database.yml
+++ b/lib/jets/turbo/templates/config/database.yml
@@ -1,6 +1,6 @@
 default: &default
   adapter:  <%= @adapter %>
-  encoding: utf8
+  encoding: utf8mb4
   pool: <%%= ENV["DB_POOL"] || 5  %>
   database: <%%= ENV['DB_NAME'] || '<%= @database_development %>' %>
 <% if @adapter == 'postgresql' -%>

--- a/spec/fixtures/apps/franky/config/database.yml
+++ b/spec/fixtures/apps/franky/config/database.yml
@@ -1,6 +1,6 @@
 default: &default
   adapter: mysql2
-  encoding: utf8
+  encoding: utf8mb4
   pool: <%= ENV["DB_POOL"] || 5  %>
   database: <%= ENV['DB_NAME'] || 'demo_dev' %>
   username: <%= ENV['DB_USER'] || 'tung' %>

--- a/spec/fixtures/db_configs/database.multi.yml
+++ b/spec/fixtures/db_configs/database.multi.yml
@@ -1,0 +1,26 @@
+default: &default
+  adapter: mysql2
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  timeout: 5000
+  encoding: utf8mb4
+
+test:
+  primary:
+    <<: *default
+    database: my_primary_database
+    user: root
+  primary_replica:
+    <<: *default
+    database: my_primary_database
+    user: root # user: root_readonly
+    replica: true
+  animals:
+    <<: *default
+    database: my_animals_database
+    user: root # user: animals_root
+    migrations_paths: db/animals_migrate
+  animals_replica:
+    <<: *default
+    database: my_animals_database
+    user: root # user: animals_readonly
+    replica: true

--- a/spec/fixtures/db_configs/database.single.yml
+++ b/spec/fixtures/db_configs/database.single.yml
@@ -1,0 +1,22 @@
+default: &default
+  adapter: mysql2
+  encoding: utf8mb4
+  pool: <%= ENV["DB_POOL"] || 5  %>
+  database: <%= ENV['DB_NAME'] || 'demo_development' %>
+  username: <%= ENV['DB_USER'] || 'root' %>
+  password: <%= ENV['DB_PASS'] %>
+  host: <%= ENV["DB_HOST"] %>
+  url: <%= ENV['DATABASE_URL'] %> # takes higher precedence than other settings
+
+development:
+  <<: *default
+  database: <%= ENV['DB_NAME'] || 'demo_development' %>
+
+test:
+  <<: *default
+  database: demo_test
+
+production:
+  <<: *default
+  database: demo_production
+  url: <%= ENV['DATABASE_URL'] %>

--- a/spec/lib/jets/application_spec.rb
+++ b/spec/lib/jets/application_spec.rb
@@ -46,4 +46,22 @@ describe Jets::Application do
       expect { Rails }.to raise_error(NameError)
     end
   end
+
+  context "database configurations" do
+    let(:app) { Jets::Application.instance }
+
+    it "standard single database config" do
+      configurations = app.load_db_config("spec/fixtures/db_configs/database.single.yml")
+      hash_config = configurations.configs_for(env_name: Jets.env).first # the test environment
+      config = hash_config.config
+      expect(config["adapter"]).to eq "mysql2"
+    end
+
+    it "standard multiple database config" do
+      configurations = app.load_db_config("spec/fixtures/db_configs/database.multi.yml")
+      hash_configs = configurations.configs_for(env_name: Jets.env, include_replicas: true)
+      spec_names = hash_configs.map { |h| h.spec_name }
+      expect(spec_names).to eq ["primary", "primary_replica", "animals", "animals_replica"]
+    end
+  end
 end


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
This is a 🧐 documentation change.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Rails 6 has been released. This upgrades jets to use Rails 6 components instead of Rails 5.
