### PR TITLE
Update prewarming docs

### DIFF
--- a/docs/_docs/prewarming.md
+++ b/docs/_docs/prewarming.md
@@ -25,6 +25,13 @@ concurrent | For each prewarming job run, this controls how many times in parall
 
 For example, with a rate of 2 hours and concurrent of 2, this results in the Lambda functions being called with a prewarm request 24 times after 24 hours (12 hours x 2).
 
+To execute prewarming, Jets will create two Lambda functions:
+
+Name | Explanation
+--- | ---
+warm | If concurrent is `1`.
+torch | If concurrent is greater `1`, the torch job will concurrently call the `warm` job.
+
 ## Public Ratio
 
 The `prewarm.public_ratio` activates extra prewarming for the internal `jets/public_controller.rb`.  The `jets/public_controller.rb` handles serving static files out of the `public` folder. The `prewarm.public_ratio` tells Jets to prewarm the public_controller's lambda function a little bit extra. You can tune the extra prewarming ratio higher or lower according to your needs.

--- a/docs/_docs/prewarming.md
+++ b/docs/_docs/prewarming.md
@@ -23,7 +23,7 @@ Option | Explanation
 rate | This controls how often the prewarming job runs.
 concurrent | For each prewarming job run, this controls how many times in parallel to hit the functions with a prewarm request.
 
-For example, with a rate of 2 hours and concurrent of 2, this results in the Lambda functions being called with a prewarm request 24 times after 24 hours (12 hours x 2).
+For example, with a rate of 2 hours and concurrent of 2, this results in the Lambda functions being called with a prewarm request 48 times after 24 hours (24 hours x 2).
 
 To execute prewarming, Jets will create two Lambda functions:
 

--- a/docs/_docs/prewarming.md
+++ b/docs/_docs/prewarming.md
@@ -18,6 +18,13 @@ end
 
 ## Rate vs Concurrency
 
+Concurrency can be helpful if requests are coming in at the same time in parallel. Example: The Lambda function gets 60 requests/minute and each request takes 1 second to process.
+
+Case 1: All 60 requests come in at the same time within the first second. Desired concurrency should be 60 otherwise 59 of 60 requests will be hit with a cold start (in worst case scenario).
+Case 2: The 60 requests come in serially each second for a minute. The same lambda "container" will be able to serve all the requests without a cold start in theory.
+
+Same would apply on traditional servers like Puma where you need more Puma threads and or processes to handle increased concurrency.
+
 Option | Explanation
 --- | ---
 rate | This controls how often the prewarming job runs.


### PR DESCRIPTION
This is a 🧐 documentation change.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

I was always wondering why Jets actually creates two additional functions, `warm` and `torch` (I found the naming not very intuitive). As I found out, the difference is that `torch` is using concurrency.

Additionally I fixed a typo in the example (please double check or elaborate why this is correct).

Last but not least, I don't really understand why concurrency is necessary and which number of concurrency I should choose for my Lambda function. My understanding so far, if I want my Lambda function to handle e.g. `20` requests concurrently, I should use concurrent `20`. The concurrent option will make sure that the function is not only prewarmed but also scaled for the amount of concurrency I expect. @tongueroo if you could confirm this and/or elaborate on it, I would include it in the PR to update the documentation.

Thanks 👍 

