### PR TITLE
Fix route params for specs

### DIFF
--- a/lib/jets/controller/middleware/local/route_matcher.rb
+++ b/lib/jets/controller/middleware/local/route_matcher.rb
@@ -5,102 +5,19 @@ class Jets::Controller::Middleware::Local
     end
 
     def find_route
-      reset_routes!
-      # Precedence:
-      # 1. Routes with no captures get highest precedence: posts/new
-      # 2. Then we consider the routes with captures: post/:id
-      #
-      # Within these 2 groups we consider the routes with the longest path first
-      # since posts/:id and posts/:id/edit can both match.
-      routes = router.ordered_routes
-      route = routes.find do |r|
-        route_found?(r)
-      end
-      route
+      Jets::Router::Finder.new(method, path).run
     end
 
-    # "hot reload" for development
-    def reset_routes!
-      return unless Jets.env.development?
+    private
 
-      Jets::Router.clear!
-      Jets.application.load_routes(refresh: true)
-    end
+      attr_reader :env
 
-    def route_found?(route)
-      request_method = @env["REQUEST_METHOD"] || "GET"
-      actual_path = @env["PATH_INFO"].sub(/^\//,'') # remove beginning slash
-
-      # Immediately stop checking when the request method: GET, POST, ANY, etc
-      # doesnt match.
-      return false if request_method != route.method and route.method != "ANY"
-
-      path = route.path
-
-      if actual_path == path
-        # regular string match detection
-        return true # exact route matches are highest precedence
+      def path
+        env["REQUEST_METHOD"] || "GET"
       end
 
-      # Check path for route capture and wildcard matches:
-      # A colon (:) means the variable has a variable
-      if path.include?(':') # 2nd highest precedence
-        capture_detection(path, actual_path) # early return true or false
-      # A star (*) means the variable has a glob
-      elsif path.include?('*') # lowest precedence
-        proxy_detection(path, actual_path) # early return true or false
-      else
-        false # reach here, means no route matched
+      def method
+        env["PATH_INFO"].sub(/^\//,'')
       end
     end
-
-    # catchall/globbing/wildcard/proxy routes. Examples:
-    #
-    #    get "files/*path", to: "files#show"
-    #    get "others/*rest", to: "others#show"
-    #    get "*catchall", to: "public_files#show" # last catchall route for Jets
-    #
-    def proxy_detection(route_path, actual_path)
-      # drop the proxy_segment
-      leading_path = route_path.split('/')[0..-2].join('/')
-
-      # get "*catchall", to: "public_files#show"
-      if leading_path.empty? # This is the last catchall route "*catchall"
-        return true # always return true here because the entire path
-        # will always match
-      end
-
-      # Other types of wildcard route:
-      #
-      #    get "files/*path", to: "files#show"
-      #    get "others/*rest", to: "others#show"
-      unless leading_path.ends_with?('/')
-        # Ensure trailing slash to make pattern matching stricter
-        leading_path = "#{leading_path}/"
-      end
-
-      pattern = "^#{leading_path}"
-      regexp = Regexp.new(pattern)
-      !!regexp.match(actual_path) # could be true or false
-    end
-
-    def capture_detection(route_path, actual_path)
-      # changes path to a string used for a regexp
-      # posts/:id/edit => posts\/(.*)\/edit
-
-      regexp_string = route_path.split('/').map do |s|
-                        s.include?(':') ? Jets::Router::Route::CAPTURE_REGEX : s
-                      end.join('\/')
-      # make sure beginning and end of the string matches
-      regexp_string = "^#{regexp_string}$"
-
-      regexp = Regexp.new(regexp_string)
-      !!regexp.match(actual_path) # could be true or false
-    end
-
-    def router
-      return @router if @router
-      @router = Jets.application.routes
-    end
-  end
 end

--- a/lib/jets/router/finder.rb
+++ b/lib/jets/router/finder.rb
@@ -1,0 +1,47 @@
+class Jets::Router
+  class Finder
+    extend Memoist
+
+    def initialize(path, method)
+      @path = path
+      @method = method.to_s.upcase
+    end
+
+    def run
+      reset_routes!
+      # Precedence:
+      # 1. Routes with no captures get highest precedence: posts/new
+      # 2. Then we consider the routes with captures: post/:id
+      #
+      # Within these 2 groups we consider the routes with the longest path first
+      # since posts/:id and posts/:id/edit can both match.
+      routes = router.ordered_routes
+      route = routes.find do |r|
+        matcher.match?(r)
+      end
+      route
+    end
+
+    private
+
+      attr_reader :path, :method
+
+      # "hot reload" for development
+      def reset_routes!
+        return unless Jets.env.development?
+
+        Jets::Router.clear!
+        Jets.application.load_routes(refresh: true)
+      end
+
+      def matcher
+        Jets::Router::Matcher.new(path, method)
+      end
+      memoize :matcher
+
+      def router
+        Jets.application.routes
+      end
+      memoize :router
+  end
+end

--- a/lib/jets/router/matcher.rb
+++ b/lib/jets/router/matcher.rb
@@ -1,0 +1,81 @@
+class Jets::Router
+  class Matcher
+    def initialize(path, method)
+      @path = path.sub(/^\//,'')
+      @method = method.to_s.upcase
+    end
+
+    def match?(route)
+      # Immediately stop checking when the request method: GET, POST, ANY, etc
+      # doesnt match.
+
+      return false if method != route.method && route.method != "ANY"
+
+      route_path = route.path
+
+      if path == route_path
+        # regular string match detection
+        return true # exact route matches are highest precedence
+      end
+
+      # Check path for route capture and wildcard matches:
+      # A colon (:) means the variable has a variable
+      if route_path.include?(':') # 2nd highest precedence
+        capture_detection(route_path, path) # early return true or false
+      # A star (*) means the variable has a glob
+      elsif route_path.include?('*') # lowest precedence
+        proxy_detection(route_path, path) # early return true or false
+      else
+        false # reach here, means no route matched
+      end
+    end
+
+    private
+
+      attr_reader :path, :method
+
+      # catchall/globbing/wildcard/proxy routes. Examples:
+      #
+      #    get "files/*path", to: "files#show"
+      #    get "others/*rest", to: "others#show"
+      #    get "*catchall", to: "public_files#show" # last catchall route for Jets
+      #
+      def proxy_detection(route_path, actual_path)
+        # drop the proxy_segment
+        leading_path = route_path.split('/')[0..-2].join('/')
+
+        # get "*catchall", to: "public_files#show"
+        if leading_path.empty? # This is the last catchall route "*catchall"
+          return true # always return true here because the entire path
+          # will always match
+        end
+
+        # Other types of wildcard route:
+        #
+        #    get "files/*path", to: "files#show"
+        #    get "others/*rest", to: "others#show"
+        unless leading_path.ends_with?('/')
+          # Ensure trailing slash to make pattern matching stricter
+          leading_path = "#{leading_path}/"
+        end
+
+        pattern = "^#{leading_path}"
+        regexp = Regexp.new(pattern)
+        !!regexp.match(actual_path) # could be true or false
+      end
+
+      def capture_detection(route_path, actual_path)
+        # changes path to a string used for a regexp
+        # posts/:id/edit => posts\/(.*)\/edit
+        regexp_string = route_path.split('/').map do |s|
+                          s.include?(':') ? Jets::Router::Route::CAPTURE_REGEX : s
+                        end.join('\/')
+        # make sure beginning and end of the string matches
+        regexp_string = "^#{regexp_string}$"
+
+        regexp = Regexp.new(regexp_string)
+
+        !!regexp.match(actual_path) # could be true or false
+      end
+  end
+end

--- a/spec/lib/jets/controller/middleware/local/route_matcher_spec.rb
+++ b/spec/lib/jets/controller/middleware/local/route_matcher_spec.rb
@@ -1,21 +1,6 @@
 describe Jets::Controller::Middleware::Local::RouteMatcher do
   let(:matcher) { Jets::Controller::Middleware::Local::RouteMatcher.new(env) }
 
-  context "get /" do
-    let(:env) do
-      { "PATH_INFO" => "/", "REQUEST_METHOD" => "GET" }
-    end
-    it "find_route finds root route" do
-      route = Jets::Router::Route.new(
-        path: "/",
-        method: :get,
-        to: "posts#new",
-      )
-      found = matcher.route_found?(route)
-      expect(found).to be true
-    end
-  end
-
   context "get posts/:id/edit" do
     let(:env) do
       { "PATH_INFO" => "/posts/tung/edit", "REQUEST_METHOD" => "GET" }
@@ -28,16 +13,6 @@ describe Jets::Controller::Middleware::Local::RouteMatcher do
         method: :get,
         to: "public_files#show",
       )
-      found = matcher.route_found?(route)
-      expect(found).to be true
-
-      route = Jets::Router::Route.new(
-        path: "posts/:id/edit",
-        method: :get,
-        to: "posts#edit",
-      )
-      found = matcher.route_found?(route)
-      expect(found).to be true
 
       route = matcher.find_route
       expect(route.path).to eq "posts/:id/edit"
@@ -115,125 +90,10 @@ describe Jets::Controller::Middleware::Local::RouteMatcher do
       { "PATH_INFO" => "/everything/else", "REQUEST_METHOD" => "GET" }
     end
 
-    it "route_found?" do
-      route = Jets::Router::Route.new(
-        path: "*catchall",
-        method: :get,
-        to: "public_files#catchall",
-      )
-      found = matcher.route_found?(route)
-      expect(found).to be true
-    end
-
     it "find_route" do
       route = matcher.find_route
       expect(route.path).to eq "*catchall"
       expect(route.method).to eq "ANY"
-    end
-  end
-
-  context "get posts/:id/edit" do
-    let(:env) do
-      { "PATH_INFO" => "/posts/tung/edit", "REQUEST_METHOD" => "GET" }
-    end
-    it "route_found?" do
-      route = Jets::Router::Route.new(
-        path: "posts/:id/edit",
-        method: :get,
-        to: "posts#edit",
-      )
-      found = matcher.route_found?(route)
-      expect(found).to be true
-    end
-  end
-
-  context "any comments/hot with get" do
-    let(:env) do
-      { "PATH_INFO" => "/comments/hot", "REQUEST_METHOD" => "GET" }
-    end
-    it "route_found?" do
-      route = Jets::Router::Route.new(
-        path: "comments/hot",
-        method: :any,
-        to: "comments#hot",
-      )
-      found = matcher.route_found?(route)
-      expect(found).to be true
-    end
-  end
-
-  context "any comments/hot with post" do
-    let(:env) do
-      { "PATH_INFO" => "/comments/hot", "REQUEST_METHOD" => "POST" }
-    end
-    it "route_found?" do
-      route = Jets::Router::Route.new(
-        path: "comments/hot",
-        method: :any,
-        to: "comments#hot",
-      )
-      found = matcher.route_found?(route)
-      expect(found).to be true
-    end
-  end
-
-  context "any comments/hot with non-matching path" do
-    let(:env) do
-      { "PATH_INFO" => "/some/other/path", "REQUEST_METHOD" => "GET" }
-    end
-    it "route_found?" do
-      route = Jets::Router::Route.new(
-        path: "comments/hot",
-        method: :any,
-        to: "comments#hot",
-      )
-      found = matcher.route_found?(route)
-      expect(found).to be false
-    end
-  end
-
-  context "get admin/pages" do
-    let(:env) do
-      { "PATH_INFO" => "/admin/pages", "REQUEST_METHOD" => "GET" }
-    end
-    it "route_found?" do
-      route = Jets::Router::Route.new(
-        path: "admin/pages",
-        method: :get,
-        to: "admin/pages#index",
-      )
-      found = matcher.route_found?(route)
-      expect(found).to be true
-    end
-  end
-
-  context "get others/my/long/path - proxy path route" do
-    let(:env) do
-      { "PATH_INFO" => "others/my/long/path", "REQUEST_METHOD" => "GET" }
-    end
-    it "route_found?" do
-      route = Jets::Router::Route.new(
-        path: "others/*proxy",
-        method: :get,
-        to: "others#all",
-      )
-      found = matcher.route_found?(route)
-      expect(found).to be true
-    end
-  end
-
-  context "get others/my/long/path - proxy path route" do
-    let(:env) do
-      { "PATH_INFO" => "others2/my/long/path", "REQUEST_METHOD" => "GET" }
-    end
-    it "not route_found?" do
-      route = Jets::Router::Route.new(
-        path: "others/*proxy",
-        method: :get,
-        to: "others#all",
-      )
-      found = matcher.route_found?(route)
-      expect(found).to be false
     end
   end
 end

--- a/spec/lib/jets/router/matcher_spec.rb
+++ b/spec/lib/jets/router/matcher_spec.rb
@@ -1,0 +1,163 @@
+describe Jets::Controller::Middleware::Local::RouteMatcher do
+  let(:matcher) { Jets::Router::Matcher.new(path, method) }
+
+  context "get /" do
+    let(:path) { "/" }
+    let(:method) { "GET" }
+
+    it "match? finds root route" do
+      route = Jets::Router::Route.new(
+        path: "/",
+        method: :get,
+        to: "posts#new",
+      )
+      found = matcher.match?(route)
+      expect(found).to be true
+    end
+  end
+
+  context "get posts/:id/edit" do
+    let(:path) { "/posts/tung/edit" }
+    let(:method) { "GET" }
+
+    it "match? finds highest precedence route" do
+      # In this case the catchall and the capture route matches
+      # But the matcher finds the route with the highest precedence
+      route = Jets::Router::Route.new(
+        path: "*catchall",
+        method: :get,
+        to: "public_files#show",
+      )
+      found = matcher.match?(route)
+      expect(found).to be true
+
+      route = Jets::Router::Route.new(
+        path: "posts/:id/edit",
+        method: :get,
+        to: "posts#edit",
+      )
+      found = matcher.match?(route)
+      expect(found).to be true
+    end
+  end
+
+  context "get everything/else catchall route" do
+    let(:path) { "/everything/else" }
+    let(:method) { "GET" }
+
+    it "match?" do
+      route = Jets::Router::Route.new(
+        path: "*catchall",
+        method: :get,
+        to: "public_files#catchall",
+      )
+      found = matcher.match?(route)
+      expect(found).to be true
+    end
+  end
+
+  context "get posts/:id/edit" do
+    let(:path) { "/posts/tung/edit" }
+    let(:method) { "GET" }
+    
+    it "match?" do
+      route = Jets::Router::Route.new(
+        path: "posts/:id/edit",
+        method: :get,
+        to: "posts#edit",
+      )
+      found = matcher.match?(route)
+      expect(found).to be true
+    end
+  end
+
+  context "any comments/hot with get" do
+    let(:path) { "/comments/hot" }
+    let(:method) { "GET" }
+
+    it "route_found?" do
+      route = Jets::Router::Route.new(
+        path: "comments/hot",
+        method: :any,
+        to: "comments#hot",
+      )
+      found = matcher.match?(route)
+      expect(found).to be true
+    end
+  end
+
+  context "any comments/hot with post" do
+    let(:path) { "/comments/hot" }
+    let(:method) { "POST" }
+
+    it "match?" do
+      route = Jets::Router::Route.new(
+        path: "comments/hot",
+        method: :any,
+        to: "comments#hot",
+      )
+      found = matcher.match?(route)
+      expect(found).to be true
+    end
+  end
+
+  context "any comments/hot with non-matching path" do
+    let(:path) { "/some/other/path" }
+    let(:method) { "GET" }
+
+    it "match?" do
+      route = Jets::Router::Route.new(
+        path: "comments/hot",
+        method: :any,
+        to: "comments#hot",
+      )
+      found = matcher.match?(route)
+      expect(found).to be false
+    end
+  end
+
+  context "get admin/pages" do
+    let(:path) { "/admin/pages" }
+    let(:method) { "GET" }
+
+    it "route_found?" do
+      route = Jets::Router::Route.new(
+        path: "admin/pages",
+        method: :get,
+        to: "admin/pages#index",
+      )
+      found = matcher.match?(route)
+      expect(found).to be true
+    end
+  end
+
+  context "get others/my/long/path - proxy path route" do
+    let(:path) { "others/my/long/path" }
+    let(:method) { "GET" }
+
+    it "match?" do
+      route = Jets::Router::Route.new(
+        path: "others/*proxy",
+        method: :get,
+        to: "others#all",
+      )
+      found = matcher.match?(route)
+      expect(found).to be true
+    end
+  end
+
+  context "get others/my/long/path - proxy path route" do
+    let(:path) { "others2/my/long/path" }
+    let(:method) { "GET" }
+
+    it "not match?" do
+      route = Jets::Router::Route.new(
+        path: "others/*proxy",
+        method: :get,
+        to: "others#all",
+      )
+      found = matcher.match?(route)
+      expect(found).to be false
+    end
+  end
+end

--- a/spec/lib/jets/spec_helpers_spec.rb
+++ b/spec/lib/jets/spec_helpers_spec.rb
@@ -68,6 +68,12 @@ describe Jets::SpecHelpers do
       expect(JSON.parse(response.body)['filter']).to eq 'abc'
     end
 
+    it "gets 200 with route params" do
+      get '/spec_helper_test/123'
+      expect(response.status).to eq 200
+      expect(JSON.parse(response.body)['id']).to eq '123'
+    end
+
     it "gets 404 with id" do
       get '/spec_helper_test/:id', id: 404
       expect(response.status).to eq 404


### PR DESCRIPTION
This is a 🐞 bug fix.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Currently, using named routes or having route parameters in specs did not work. For instance:

```ruby
get '/spec_helper_test/123' # route not found
get helper_path(123) # route not found

get '/spec_helper_test/:id', id: 123 # works
```

The latter syntax is quite awkward and not intuitive.

This commit extracts the route matcher and finder in dedicated classes to reuse them in the middleware as well as in the spec helper.

The actual change is quite small, however, the diff is big because extracting the code from the middleware to the `Matcher` and `Finder` classes.

Let me know if I should do any adaptions or if you have some feedback. Thanks!
