### PR TITLE
Fix autoload config

### DIFF
--- a/docs/_docs/app-config.md
+++ b/docs/_docs/app-config.md
@@ -3,7 +3,7 @@ title: Application Configuration
 nav_order: 35
 ---
 
-You can set application-wide configurations in the `config/application.rb` file. You can configure global things like project_name, extra_autoload_paths, function timeout, memory size, etc. Example:
+You can set application-wide configurations in the `config/application.rb` file. You can configure global things like project_name, autoload_paths, function timeout, memory size, etc. Example:
 
 `config/application.rb`:
 
@@ -14,7 +14,7 @@ Jets.application.configure do
   # config.prewarm.rate = '30 minutes' # default is '30 minutes'
   # config.prewarm.concurrency = 1 # default is 1
   # config.env_extra = 2 # change also set this with JETS_ENV_EXTRA
-  # config.extra_autoload_paths = []
+  # config.autoload_paths = []
 
   config.function.timeout = 30
   # config.function.role = "arn:aws:iam::#{ENV['AWS_ACCOUNT_ID']}:role/service-role/pre-created"

--- a/docs/_docs/extras/upgrading.md
+++ b/docs/_docs/extras/upgrading.md
@@ -15,6 +15,7 @@ The following table summarizes the releases and upgrade paths.
 
 Version | Notes | Blue-Green? | Run jets upgrade?
 --- | --- | --- | ---
+2.1.1 | Change `config.extra_autoload_paths` to `config.autoload_paths` | No | Yes
 2.0.0 | Add csrf forgery protection. The `jets upgrade` commands updates your code with the csrf logic. New apps generated with `jets new` does this already.  | No | Yes
 1.4.11 | Removed vendor/dynomite gem. Must add dynomite to Gemfile now. New apps generated with `jets new` does this.  | No | Yes
 1.3.0 | Official AWS Ruby Support added.  Removed longer needed `config.ruby.lazy_load` feature. | No | No

--- a/lib/jets/application.rb
+++ b/lib/jets/application.rb
@@ -13,8 +13,9 @@ class Jets::Application
 
   def setup!
     load_default_config
-    autoload_paths = config.autoload_paths + config.extra_autoload_paths
-    setup_auto_load_paths(autoload_paths)
+    setup_autoload_paths
+    setup_ignore_paths
+    autoload_setup
   end
 
   def configs!
@@ -99,14 +100,29 @@ class Jets::Application
     end
   end
 
-  def setup_auto_load_paths(autoload_paths=default_autoload_paths)
-    loader = Jets::Autoloaders.main
+  def main_loader
+    Jets::Autoloaders.main
+  end
+
+  def setup_autoload_paths
+    autoload_paths = default_autoload_paths + config.autoload_paths
     autoload_paths.each do |path|
       next unless File.exist?(path)
-      loader.push_dir(path)
+      main_loader.push_dir(path)
     end
-    loader.enable_reloading if Jets.env.development?
-    loader.setup
+  end
+
+  # Allow use to add config.ignore_paths just in case there's some case Jets hasn't considered
+  def setup_ignore_paths
+    ignore_paths = default_ignore_paths + config.ignore_paths
+    ignore_paths.each do |path|
+      main_loader.ignore("#{Jets.root}/#{path}")
+    end
+  end
+
+  def autoload_setup
+    main_loader.enable_reloading if Jets.env.development?
+    main_loader.setup # only respected on the first call
   end
 
   def each_app_autoload_path(expression)

--- a/lib/jets/application.rb
+++ b/lib/jets/application.rb
@@ -15,7 +15,7 @@ class Jets::Application
     load_default_config
     setup_autoload_paths
     setup_ignore_paths
-    autoload_setup
+    main_loader_setup
   end
 
   def configs!
@@ -120,7 +120,7 @@ class Jets::Application
     end
   end
 
-  def autoload_setup
+  def main_loader_setup
     main_loader.enable_reloading if Jets.env.development?
     main_loader.setup # only respected on the first call
   end

--- a/lib/jets/application/defaults.rb
+++ b/lib/jets/application/defaults.rb
@@ -54,8 +54,8 @@ class Jets::Application
       config = ActiveSupport::OrderedOptions.new
       config.project_name = parse_project_name # must set early because other configs requires this
       config.cors = false
-      config.autoload_paths = default_autoload_paths
-      config.extra_autoload_paths = []
+      config.autoload_paths = [] # allows for customization
+      config.ignore_paths = [] # allows for customization
       config.logger = Jets::Logger.new($stderr)
 
       # function properties defaults
@@ -175,6 +175,13 @@ class Jets::Application
       paths << "#{Jets.root}/app/shared/extensions"
 
       paths
+    end
+
+    def default_ignore_paths
+      %w[
+        app/functions
+        app/shared/functions
+      ]
     end
   end
 end

--- a/lib/jets/autoloaders.rb
+++ b/lib/jets/autoloaders.rb
@@ -27,7 +27,6 @@ module Jets
         Zeitwerk::Loader.new.tap do |loader|
           loader.tag = "jets.main"
           # loader.inflector = Inflector.new # TODO: allow custom app inflector
-          loader.ignore("#{Jets.root}/app/shared/functions")
         end
       end
       memoize :main

--- a/lib/jets/autoloaders.rb
+++ b/lib/jets/autoloaders.rb
@@ -27,6 +27,8 @@ module Jets
         Zeitwerk::Loader.new.tap do |loader|
           loader.tag = "jets.main"
           # loader.inflector = Inflector.new # TODO: allow custom app inflector
+          # The main loader is configured later on in Jets::Application#setup_autoload_paths
+          # because it needs access to Jets.root and Jets.config settings
         end
       end
       memoize :main

--- a/lib/jets/cli.rb
+++ b/lib/jets/cli.rb
@@ -78,8 +78,7 @@ class Jets::CLI
 
     # jets generate is a special command requires doesn't puts out the help menu automatically when
     # `jets generate` is called without additional args.  We'll take it over early and fix it here.
-    autocomplete_command = Jets::Commands::Base.autocomplete(args[0])
-    generate = autocomplete_command == "generate"
+    generate = full_command == "generate"
 
     if generate && ((args.size == 1 || help_flags.include?(args.last)) || args.size == 2)
       puts Jets::Generator.help

--- a/lib/jets/commands/base.rb
+++ b/lib/jets/commands/base.rb
@@ -138,7 +138,6 @@ class Jets::Commands::Base < Thor
     def eager_load!
       return if Jets::Turbo.afterburner?
 
-      Jets.application.setup_auto_load_paths # in case an app/extension is defined
       Jets::Autoloaders.once.eager_load
     end
     memoize :eager_load!

--- a/lib/jets/commands/templates/skeleton/config/application.rb.tt
+++ b/lib/jets/commands/templates/skeleton/config/application.rb.tt
@@ -12,7 +12,7 @@ Jets.application.configure do
 <% end -%>
 
   # config.env_extra = 2 # can also set this with JETS_ENV_EXTRA
-  # config.extra_autoload_paths = []
+  # config.autoload_paths = []
 
   # config.asset_base_url = 'https://cloudfront.domain.com/assets' # example
 

--- a/lib/jets/commands/upgrade.rb
+++ b/lib/jets/commands/upgrade.rb
@@ -14,6 +14,7 @@ module Jets::Commands
       inject_csrf_meta_tags
       update_crud_js
       update_config_application_rb
+      update_autoload_paths_config
       puts "Upgrade complete."
     end
 
@@ -74,6 +75,31 @@ module Jets::Commands
       content = lines.join
       IO.write(app_rb, content)
       puts "Update: #{app_rb} with default_protect_from_forgery"
+    end
+
+    def update_autoload_paths_config
+      app_rb = "config/application.rb"
+      lines = IO.readlines(app_rb)
+
+      new_config = lines.find { |l| l.include?('config.autoload_paths') }
+      return if new_config
+
+      old_config = lines.find { |l| l.include?('config.extra_autoload_paths') }
+      return unless old_config
+
+      lines.map! do |line|
+        md = line.match(/config\.extra_autoload_paths(.*)/)
+        if md
+          rest = md[1]
+          "  config.autoload_paths#{rest}"
+        else
+          line
+        end
+      end
+
+      content = lines.join
+      IO.write(app_rb, content)
+      puts "Update: #{app_rb} with config.autoload_paths"
     end
   end
 end

--- a/lib/jets/lambda/dsl.rb
+++ b/lib/jets/lambda/dsl.rb
@@ -401,19 +401,4 @@ module Jets::Lambda::Dsl
       end
     end # end of class << self
   end # end of included
-
-  def self.add_custom_resource_extensions(base)
-    base_path = "#{Jets.root}/app/extensions"
-    Dir.glob("#{base_path}/**/*.rb").each do |path|
-      next unless File.file?(path)
-
-      class_name = path.sub("#{base_path}/", '').sub(/\.rb/,'').camelize
-      klass = class_name.constantize # autoload
-      base.extend(klass)
-    end
-  end
-
-  def self.included(base)
-    add_custom_resource_extensions(base)
-  end
 end

--- a/spec/fixtures/apps/franky/config/application.rb
+++ b/spec/fixtures/apps/franky/config/application.rb
@@ -1,7 +1,7 @@
 Jets.application.configure do
   config.project_name = "demo"
   # config.env_extra = 2
-  # config.extra_autoload_paths = []
+  # config.autoload_paths = []
 
   config.cors = true
 


### PR DESCRIPTION
This is a 🐞 bug fix.
🙋‍♂️ feature or enhancement.
This is a 🧐 documentation change.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fix `config.autoload_paths`. Also renamed it from `config.extra_autoload_paths` to `config.autoload_paths`. The [jets upgrade](https://rubyonjets.com/docs/extras/upgrading/) command will handle this.

## Context

https://community.rubyonjets.com/t/config-extra-autoload-paths-doesnt-seem-to-work/224/3

