### PR TITLE
paginate api gateway resources to support more routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,13 @@
 *.gem
 *.rbc
 .bundle
+.byebug_history
 .config
 .yardoc
-InstalledFiles
 _yardoc
 coverage
 doc/
+InstalledFiles
 lib/bundler/man
 pkg
 rdoc
@@ -15,10 +16,9 @@ test/tmp
 test/version_tmp
 tmp
 
-spec/fixtures/project/handlers
 .codebuild/definitions
-demo*
 /html
+/demo
+Gemfile.lock
 spec/fixtures/apps/franky/dynamodb/migrate
-Gemfile.lock 
-.byebug_history
+spec/fixtures/project/handlers

--- a/lib/jets/cfn/builders/api_resources_builder.rb
+++ b/lib/jets/cfn/builders/api_resources_builder.rb
@@ -1,0 +1,46 @@
+module Jets::Cfn::Builders
+  class ApiResourcesBuilder
+    include Interface
+    include Jets::AwsServices
+
+    def initialize(options={}, paths=[], page)
+      @options, @paths, @page = options, paths, page
+      @template = ActiveSupport::HashWithIndifferentAccess.new(Resources: {})
+    end
+
+    # compose is an interface method
+    def compose
+      return unless @options[:templates] || @options[:stack_type] != :minimal
+
+      add_rest_api_parameter
+      add_gateway_routes
+    end
+
+    # template_path is an interface method
+    def template_path
+      Jets::Naming.api_resources_template_path(@page)
+    end
+
+    def add_rest_api_parameter
+      add_parameter("RestApi", Description: "RestApi")
+    end
+
+    def add_gateway_routes
+      @paths.each do |path|
+        homepage = path == ''
+        next if homepage # handled by RootResourceId output already
+
+        resource = Jets::Resource::ApiGateway::Resource.new(path)
+        add_resource(resource)
+        add_outputs(resource.outputs)
+
+        parent_path = resource.parent_path_parameter
+        add_parameter(parent_path) unless part_of_template?(parent_path)
+      end
+    end
+
+    def part_of_template?(parent_path)
+      @template["Resources"].key?(parent_path)
+    end
+  end
+end

--- a/lib/jets/cfn/built_template.rb
+++ b/lib/jets/cfn/built_template.rb
@@ -1,0 +1,15 @@
+module Jets::Cfn
+  # Caches the built template to reduce filesystem IO calls.
+  class BuiltTemplate
+    class << self
+      @@cache = {}
+      def get(path)
+        if @@cache[path]
+          @@cache[path] # using cache
+        else
+          @@cache[path] = YAML.load_file(path) # setting and using cache
+        end
+      end
+    end
+  end
+end

--- a/lib/jets/naming.rb
+++ b/lib/jets/naming.rb
@@ -30,6 +30,10 @@ class Jets::Naming
       "#{template_path_prefix}-api-gateway.yml"
     end
 
+    def api_resources_template_path(page)
+      "#{template_path_prefix}-api-resources-#{page}.yml"
+    end
+
     def api_deployment_template_path
       "#{template_path_prefix}-api-deployment.yml"
     end

--- a/lib/jets/resource/api_gateway/resource.rb
+++ b/lib/jets/resource/api_gateway/resource.rb
@@ -37,14 +37,18 @@ module Jets::Resource::ApiGateway
       path.empty? ? 'Homepage route: /' : "Route for: /#{path}"
     end
 
-    def parent_id
+    def parent_path_parameter
       if @path.include?('/') # posts/:id or posts/:id/edit
         parent_path = @path.split('/')[0..-2].join('/')
         parent_logical_id = path_logical_id(parent_path)
-        "!Ref " + Jets::Resource.truncate_id("#{parent_logical_id}ApiResource")
+        Jets::Resource.truncate_id("#{parent_logical_id}ApiResource")
       else
-        "!GetAtt #{RestApi.logical_id(@internal)}.RootResourceId"
+        "RootResourceId"
       end
+    end
+
+    def parent_id
+      "!Ref " + parent_path_parameter
     end
 
     def path_part

--- a/lib/jets/resource/api_gateway/rest_api/change_detection.rb
+++ b/lib/jets/resource/api_gateway/rest_api/change_detection.rb
@@ -4,39 +4,7 @@ class Jets::Resource::ApiGateway::RestApi
     include Jets::AwsServices
 
     def changed?
-      return false unless parent_stack_exists?
-      current_binary_media_types != new_binary_media_types ||
       Routes.changed?
-    end
-
-    def new_binary_media_types
-      rest_api = Jets::Resource::ApiGateway::RestApi.new
-      rest_api.binary_media_types
-    end
-    memoize :new_binary_media_types
-
-    # Duplicated in rest_api/change_detection.rb, base_path/role.rb, rest_api/routes.rb
-    def current_binary_media_types
-      return nil unless parent_stack_exists?
-
-      stack = cfn.describe_stacks(stack_name: parent_stack_name).stacks.first
-
-      api_gateway_stack_arn = lookup(stack[:outputs], "ApiGateway")
-
-      stack = cfn.describe_stacks(stack_name: api_gateway_stack_arn).stacks.first
-      rest_api_id = lookup(stack[:outputs], "RestApi")
-
-      resp = apigateway.get_rest_api(rest_api_id: rest_api_id)
-      resp.binary_media_types
-    end
-    memoize :current_binary_media_types
-
-    def parent_stack_exists?
-      stack_exists?(parent_stack_name)
-    end
-
-    def parent_stack_name
-      Jets::Naming.parent_stack_name
     end
   end
 end

--- a/lib/jets/resource/api_gateway/rest_api/routes/change.rb
+++ b/lib/jets/resource/api_gateway/rest_api/routes/change.rb
@@ -1,8 +1,16 @@
 # Detects route changes
 class Jets::Resource::ApiGateway::RestApi::Routes
   class Change
+    include Jets::AwsServices
+
     def changed?
-      To.changed? || Variable.changed? || ENV['JETS_REPLACE_API']
+      return false unless parent_stack_exists?
+
+      MediaTypes.changed? || To.changed? || Variable.changed? || Page.changed? || ENV['JETS_REPLACE_API']
+    end
+
+    def parent_stack_exists?
+      stack_exists?(Jets::Naming.parent_stack_name)
     end
   end
 end

--- a/lib/jets/resource/api_gateway/rest_api/routes/change/base.rb
+++ b/lib/jets/resource/api_gateway/rest_api/routes/change/base.rb
@@ -3,6 +3,10 @@ class Jets::Resource::ApiGateway::RestApi::Routes::Change
     extend Memoist
     include Jets::AwsServices
 
+    def self.changed?
+      new.changed?
+    end
+
     # Build up deployed routes from the existing CloudFormation resources.
     def deployed_routes
       routes = []

--- a/lib/jets/resource/api_gateway/rest_api/routes/change/media_types.rb
+++ b/lib/jets/resource/api_gateway/rest_api/routes/change/media_types.rb
@@ -1,0 +1,36 @@
+class Jets::Resource::ApiGateway::RestApi::Routes::Change
+  class MediaTypes < Base
+    def changed?
+      current_binary_media_types != new_binary_media_types
+    end
+
+    def new_binary_media_types
+      rest_api = Jets::Resource::ApiGateway::RestApi.new
+      rest_api.binary_media_types
+    end
+    memoize :new_binary_media_types
+
+    def current_binary_media_types
+      return nil unless parent_stack_exists?
+
+      stack = cfn.describe_stacks(stack_name: parent_stack_name).stacks.first
+
+      api_gateway_stack_arn = lookup(stack[:outputs], "ApiGateway")
+
+      stack = cfn.describe_stacks(stack_name: api_gateway_stack_arn).stacks.first
+      rest_api_id = lookup(stack[:outputs], "RestApi")
+
+      resp = apigateway.get_rest_api(rest_api_id: rest_api_id)
+      resp.binary_media_types
+    end
+    memoize :current_binary_media_types
+
+    def parent_stack_exists?
+      stack_exists?(parent_stack_name)
+    end
+
+    def parent_stack_name
+      Jets::Naming.parent_stack_name
+    end
+  end
+end

--- a/lib/jets/resource/api_gateway/rest_api/routes/change/page.rb
+++ b/lib/jets/resource/api_gateway/rest_api/routes/change/page.rb
@@ -1,0 +1,93 @@
+class Jets::Resource::ApiGateway::RestApi::Routes::Change
+  class Page < Base
+    def changed?
+      route_page_moved? || old_api_template?
+    end
+
+    def route_page_moved?
+      moved?(new_pages, deployed_pages)
+    end
+
+    # Routes page to logical ids
+    def moved?(new_pages, deployed_pages)
+      not_moved = true # page has not moved
+      new_pages.each do |logical_id, new_page_number|
+        if !deployed_pages[logical_id].nil? && deployed_pages[logical_id] != new_page_number
+          not_moved = false # page has moved
+          break
+        end
+      end
+      !not_moved # moved
+    end
+
+    def new_pages
+      local_logical_ids_map
+    end
+    memoize :new_pages
+
+    def deployed_pages
+      remote_logical_ids_map
+    end
+    memoize :deployed_pages
+
+    # logical id to page map
+    # Important: In Cfn::Builders::ApiGatewayBuilder, the add_gateway_routes and ApiResourcesBuilder needs to run
+    # before the parent add_gateway_rest_api method.
+    def local_logical_ids_map(path_expression="#{Jets::Naming.template_path_prefix}-api-resources-*.yml")
+      logical_ids = {} # logical id => page number
+
+      Dir.glob(path_expression).each do |path|
+        md = path.match(/-api-resources-(\d+).yml/)
+        page_number = md[1]
+
+        template = Jets::Cfn::BuiltTemplate.get(path)
+        template['Resources'].keys.each do |logical_id|
+          logical_ids[logical_id] = page_number
+        end
+      end
+
+      logical_ids
+    end
+
+    # aws cloudformation describe-stack-resources --stack-name demo-dev-ApiResources1-DYGLIEY3VAWT | jq -r '.StackResources[].LogicalResourceId'
+    def remote_logical_ids_map
+      logical_ids = {} # logical id => page number
+
+      parent_resources.each do |resource|
+        stack_name = resource.physical_resource_id # full physical id can be used as stack name also
+        regexp = Regexp.new("#{Jets.config.project_namespace}-ApiResources(\\d+)-") # tricky to escape \d pattern
+        md = stack_name.match(regexp)
+        if md
+          page_number = md[1]
+
+          resp = cfn.describe_stack_resources(stack_name: stack_name)
+          resp.stack_resources.map(&:logical_resource_id).each do |logical_id|
+            logical_ids[logical_id] = page_number
+          end
+        end
+      end
+
+      logical_ids
+    end
+
+    def old_api_template?
+      logical_resource_ids = parent_resources.map(&:logical_resource_id)
+
+      api_gateway_found = logical_resource_ids.detect do |logical_id|
+        logical_id == "ApiGateway"
+      end
+      return false unless api_gateway_found
+
+      api_resources_found = logical_resource_ids.detect do |logical_id|
+        logical_id.match(/^ApiResources\d+$/)
+      end
+      !api_resources_found # if api_resources_found then it's the new structure. so opposite is old structure
+    end
+
+    def parent_resources
+      resp = cfn.describe_stack_resources(stack_name: Jets::Naming.parent_stack_name)
+      resp.stack_resources
+    end
+    memoize :parent_resources
+  end
+end

--- a/lib/jets/resource/api_gateway/rest_api/routes/change/to.rb
+++ b/lib/jets/resource/api_gateway/rest_api/routes/change/to.rb
@@ -1,10 +1,6 @@
 # Detects route to changes
 class Jets::Resource::ApiGateway::RestApi::Routes::Change
   class To < Base
-    def self.changed?
-      new.changed?
-    end
-
     def changed?
       deployed_routes.each do |deployed_route|
         new_route = find_comparable_route(deployed_route)

--- a/lib/jets/resource/api_gateway/rest_api/routes/change/variable.rb
+++ b/lib/jets/resource/api_gateway/rest_api/routes/change/variable.rb
@@ -1,10 +1,6 @@
 # Detects route variable changes
 class Jets::Resource::ApiGateway::RestApi::Routes::Change
   class Variable < Base
-    def self.changed?
-      new.changed?
-    end
-
     def changed?
       changed = false
       deployed_routes.each do |deployed_route|

--- a/lib/jets/resource/child_stack/api_resource.rb
+++ b/lib/jets/resource/child_stack/api_resource.rb
@@ -1,0 +1,60 @@
+# Implements:
+#
+#   definition
+#   template_filename
+#
+module Jets::Resource::ChildStack
+  class ApiResource < Base
+    def initialize(*)
+      super
+      @page = @options[:page]
+    end
+
+    def definition
+      {
+        "api_resources_#{@page}" =>  {
+          type: "AWS::CloudFormation::Stack",
+          # depends_on: "ApiGateway", # CloudFormation seems to be smart enough
+          properties: {
+            template_url: template_url,
+            parameters: parameters,
+          }
+        }
+      }
+    end
+
+    def parameters
+      params = {}
+      # Since dont have all the info required.
+      # Read the template back to find the parameters required.
+      # Actually might be easier to rationalize this approach.
+      template_path = Jets::Naming.api_resources_template_path(@page)
+      template = Jets::Cfn::BuiltTemplate.get(template_path)
+      template['Parameters'].keys.each do |p|
+        case p
+        when "RestApi"
+          params[p] = "!GetAtt ApiGateway.Outputs.RestApi"
+        when "RootResourceId"
+          params[p] = "!GetAtt ApiGateway.Outputs.RootResourceId"
+        else
+          params[p] = "!GetAtt #{api_resource_page(p)}.Outputs.#{p}"
+        end
+      end
+      params
+    end
+
+    def api_resource_page(parameter)
+      Page.logical_id(parameter)
+    end
+
+    def outputs
+      {
+        logical_id => "!Ref #{logical_id}",
+      }
+    end
+
+    def template_filename
+      "#{Jets.config.project_namespace}-api-resources-#{@page}.yml"
+    end
+  end
+end

--- a/lib/jets/resource/child_stack/api_resource/page.rb
+++ b/lib/jets/resource/child_stack/api_resource/page.rb
@@ -1,0 +1,20 @@
+class Jets::Resource::ChildStack::ApiResource
+  # Find the ApiResource Page that contains the AWS::ApiGateway::Resource
+  # Returns: logical id of ApiResource Page
+  class Page
+    def self.logical_id(parameter)
+      expression = "#{Jets::Naming.template_path_prefix}-api-resources-*"
+      # IE: path: #{Jets.build_root}/templates/demo-dev-2-api-resources-1.yml"
+      template_paths = Dir.glob(expression).sort.to_a
+      found_template = template_paths.detect do |path|
+        next unless File.file?(path)
+
+        template = Jets::Cfn::BuiltTemplate.get(path)
+        template['Outputs'].keys.include?(parameter)
+      end
+      md = found_template.match(/-(api-resources-\d+)/)
+
+      md[1].underscore.camelize # IE: ApiResources1
+    end
+  end
+end

--- a/spec/fixtures/resource_pages/demo-test-api-resources-1.yml
+++ b/spec/fixtures/resource_pages/demo-test-api-resources-1.yml
@@ -1,0 +1,25 @@
+---
+Resources:
+  HiApiResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !Ref RootResourceId
+      PathPart: hi
+      RestApiId: !Ref RestApi
+  Hi1ApiResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !Ref HiApiResource
+      PathPart: '1'
+      RestApiId: !Ref RestApi
+Parameters:
+  RestApi:
+    Type: String
+    Description: RestApi
+  RootResourceId:
+    Type: String
+Outputs:
+  HiApiResource:
+    Value: !Ref HiApiResource
+  Hi1ApiResource:
+    Value: !Ref Hi1ApiResource

--- a/spec/fixtures/resource_pages/demo-test-api-resources-2.yml
+++ b/spec/fixtures/resource_pages/demo-test-api-resources-2.yml
@@ -1,0 +1,25 @@
+---
+Resources:
+  Hi2ApiResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !Ref HiApiResource
+      PathPart: '2'
+      RestApiId: !Ref RestApi
+  Hi3ApiResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !Ref HiApiResource
+      PathPart: '3'
+      RestApiId: !Ref RestApi
+Parameters:
+  RestApi:
+    Type: String
+    Description: RestApi
+  HiApiResource:
+    Type: String
+Outputs:
+  Hi2ApiResource:
+    Value: !Ref Hi2ApiResource
+  Hi3ApiResource:
+    Value: !Ref Hi3ApiResource

--- a/spec/fixtures/resource_pages/demo-test-api-resources-3.yml
+++ b/spec/fixtures/resource_pages/demo-test-api-resources-3.yml
@@ -1,0 +1,17 @@
+---
+Resources:
+  Hi4ApiResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !Ref HiApiResource
+      PathPart: '4'
+      RestApiId: !Ref RestApi
+Parameters:
+  RestApi:
+    Type: String
+    Description: RestApi
+  HiApiResource:
+    Type: String
+Outputs:
+  Hi4ApiResource:
+    Value: !Ref Hi4ApiResource

--- a/spec/lib/jets/cfn/builders/api_gateway_builder_spec.rb
+++ b/spec/lib/jets/cfn/builders/api_gateway_builder_spec.rb
@@ -4,15 +4,12 @@ describe Jets::Cfn::Builders::ApiGatewayBuilder do
   end
 
   describe "ApiGatewayBuilder" do
-    it "builds a child stack with shared api gateway resources" do
+    it "builds a child stack with api gateway rest api" do
       builder.compose
       # puts builder.text # uncomment to see template text
 
       resources = builder.template["Resources"]
       expect(resources).to include("RestApi")
-      # Probably at least one route or AWS::ApiGateway::Resource is created
-      resource_types = resources.values.map { |i| i["Type"] }
-      expect(resource_types).to include("AWS::ApiGateway::Resource")
 
       expect(builder.template_path).to eq "#{Jets.build_root}/templates/demo-test-api-gateway.yml"
     end

--- a/spec/lib/jets/cfn/builders/api_resources_builder_spec.rb
+++ b/spec/lib/jets/cfn/builders/api_resources_builder_spec.rb
@@ -1,0 +1,26 @@
+describe Jets::Cfn::Builders::ApiResourcesBuilder do
+  let(:builder) do
+    Jets::Cfn::Builders::ApiResourcesBuilder.new({}, paths, page)
+  end
+  let(:paths) { Jets::Router.all_paths }
+  let(:page)  { 1 }
+
+  describe "ApiResourcesBuilder" do
+    it "builds a child stack with shared api gateway resources" do
+      builder.compose
+      # puts builder.text # uncomment to see template text
+
+      template = builder.template
+      resources = template["Resources"]
+      # Probably at least one route or AWS::ApiGateway::Resource is created
+      resource_types = resources.values.map { |i| i["Type"] }
+      expect(resource_types).to include("AWS::ApiGateway::Resource")
+
+      # Sanity check. Pretty much all AWS::ApiGateway::Resource resources will have an output
+      outputs = template["Outputs"]
+      expect(outputs).not_to be_empty
+
+      expect(builder.template_path).to eq "#{Jets.build_root}/templates/demo-test-api-resources-1.yml"
+    end
+  end
+end

--- a/spec/lib/jets/resource/api_gateway/resource_spec.rb
+++ b/spec/lib/jets/resource/api_gateway/resource_spec.rb
@@ -37,7 +37,7 @@ describe Jets::Resource::ApiGateway::Resource do
       expect(resource.logical_id).to eq "PostsApiResource"
       properties = resource.properties
       expect(properties["PathPart"]).to eq "posts"
-      expect(properties["ParentId"]).to eq "!GetAtt RestApi.RootResourceId"
+      expect(properties["ParentId"]).to eq "!Ref RootResourceId"
     end
   end
 
@@ -68,7 +68,7 @@ describe Jets::Resource::ApiGateway::Resource do
       expect(resource.logical_id).to eq "UrlWithDashApiResource"
       properties = resource.properties
       expect(properties["PathPart"]).to eq "url-with-dash"
-      expect(properties["ParentId"]).to eq "!GetAtt RestApi.RootResourceId"
+      expect(properties["ParentId"]).to eq "!Ref RootResourceId"
     end
   end
 

--- a/spec/lib/jets/resource/api_gateway/rest_api/routes/change/page_spec.rb
+++ b/spec/lib/jets/resource/api_gateway/rest_api/routes/change/page_spec.rb
@@ -1,0 +1,103 @@
+require 'recursive-open-struct'
+
+describe Jets::Resource::ApiGateway::RestApi::Routes::Change::Page do
+  let(:page) do
+    Jets::Resource::ApiGateway::RestApi::Routes::Change::Page.new
+  end
+  let(:path) { 'spec/fixtures/resource_pages/demo-test-api-resources-1.yml' }
+  let(:page_number) { 1 }
+
+  context "moved?" do
+    it "same routes" do
+      new_pages = {
+        HiApiResource:  1,
+        Hi1ApiResource: 1,
+        Hi2ApiResource: 2,
+        Hi3ApiResource: 2,
+        Hi4ApiResource: 3,
+      }
+      deployed_pages = {
+        HiApiResource:  1,
+        Hi1ApiResource: 1,
+        Hi2ApiResource: 2,
+        Hi3ApiResource: 2,
+        Hi4ApiResource: 3,
+      }
+      moved = page.moved?(new_pages, deployed_pages)
+      expect(moved).to be false
+    end
+
+    it "new routes" do
+      new_pages = {
+        HiApiResource:  1,
+        Hi1ApiResource: 1,
+        Hi2ApiResource: 2,
+        Hi3ApiResource: 2,
+        Hi4ApiResource: 3,
+      }
+      deployed_pages = {
+        HiApiResource:  1,
+      }
+      moved = page.moved?(new_pages, deployed_pages)
+      expect(moved).to be false
+    end
+
+    it "route moved page" do
+      new_pages = {
+        HiApiResource:  1,
+        Hi1ApiResource: 1,
+        Hi2ApiResource: 2, # <= moved
+        Hi3ApiResource: 2,
+        Hi4ApiResource: 3,
+      }
+      deployed_pages = {
+        HiApiResource:  1,
+        Hi1ApiResource: 1,
+        Hi2ApiResource: 1, # <= moved
+        Hi3ApiResource: 2,
+        Hi4ApiResource: 3,
+      }
+      moved = page.moved?(new_pages, deployed_pages)
+      expect(moved).to be true
+    end
+  end
+
+  context "local_logical_ids_map" do
+    it "load map from generated templates" do
+      logical_ids = page.local_logical_ids_map("spec/fixtures/resource_pages/demo-test-api-resources-*.yml")
+      expected = {
+        "HiApiResource"=>"1",
+        "Hi1ApiResource"=>"1",
+        "Hi2ApiResource"=>"2",
+        "Hi3ApiResource"=>"2",
+        "Hi4ApiResource"=>"3",
+      }
+      expect(logical_ids).to eq(expected)
+    end
+  end
+
+  context "remote_logical_ids_map" do
+    it "load map from deployed cloudformation stack" do
+      cfn = double(:cfn).as_null_object
+      child_stacks = OpenStruct.new(
+        stack_resources: [
+          OpenStruct.new(physical_resource_id: "demo-test-ApiResources1-")
+        ]
+      )
+      api_resources = OpenStruct.new(
+        stack_resources: [
+          OpenStruct.new(logical_resource_id: "HiApiResource"),
+          OpenStruct.new(logical_resource_id: "Hi1ApiResource"),
+        ]
+      )
+
+      allow(cfn).to receive(:describe_stack_resources).and_return(child_stacks)
+      allow(cfn).to receive(:describe_stack_resources).with(stack_name: "demo-test-ApiResources1-").and_return(api_resources)
+      allow(page).to receive(:cfn).and_return(cfn)
+
+      logical_ids = page.remote_logical_ids_map
+      expected = {"HiApiResource"=>"1", "Hi1ApiResource"=>"1"}
+      expect(logical_ids).to eq(expected)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,10 @@ module Helpers
   def json_file(path)
     JSON.load(IO.read(path))
   end
+
+  def yaml_file(path)
+    YAML.load_file(path)
+  end
 end
 
 RSpec.configure do |c|


### PR DESCRIPTION
This is a 🙋‍♂️ feature or enhancement.
This is a 🧐 documentation change.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

This allows apps to have more than 60 routes if needed.

* Also, update route change detection to account for pagination.

## Context

https://community.rubyonjets.com/t/cloudformation-outputs-limits-60/246/3

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
