### PR TITLE
rate limit backoff

### DIFF
--- a/lib/jets/commands/clean/log.rb
+++ b/lib/jets/commands/clean/log.rb
@@ -19,10 +19,27 @@ class Jets::Commands::Clean
       say "Removing CloudWatch logs for #{prefix_guess}..."
       log_groups.each do |g|
         next if keep_log_group?(g.log_group_name)
-        logs.delete_log_group(log_group_name: g.log_group_name) unless @options[:noop]
+        delete_log_group(g.log_group_name) unless @options[:noop]
         say "Removed log group: #{g.log_group_name}"
       end
       say "Removed CloudWatch logs for #{prefix_guess}"
+    end
+
+    def delete_log_group(log_group_name)
+      retries = 0
+      logs.delete_log_group(log_group_name: log_group_name)
+    rescue Aws::CloudWatchLogs::Errors::ThrottlingException => e
+      retries += 1
+      seconds = 2 ** retries
+
+      puts "WARN: delete_log_group #{e.class} #{e.message}".color(:yellow)
+      puts "Backing off and will retry in #{seconds} seconds."
+      sleep(seconds)
+      if seconds > 90 # 2 ** 6 is 64 so will give up after 6 retries
+        puts "Giving up after #{retries} retries"
+      else
+        retry
+      end
     end
 
     def clean_deploys

--- a/lib/jets/commands/deploy.rb
+++ b/lib/jets/commands/deploy.rb
@@ -1,3 +1,5 @@
+require "aws-sdk-core"
+
 module Jets::Commands
   class Deploy
     extend Memoist
@@ -7,6 +9,7 @@ module Jets::Commands
     end
 
     def run
+      aws_config_update!
       deployment_env = Jets.config.project_namespace.color(:green)
       puts "Deploying to Lambda #{deployment_env} environment..."
       return if @options[:noop]
@@ -32,6 +35,29 @@ module Jets::Commands
       # TODO: possible deploy hook point: before_ship
       create_s3_event_buckets
       ship(stack_type: :full, s3_bucket: s3_bucket)
+    end
+
+    # Override the AWS retry settings during a deploy.
+    #
+    # The aws-sdk-core has expondential backup with this formula:
+    #
+    #   2 ** c.retries * c.config.retry_base_delay
+    #
+    # So the max delay will be 2 ** 7 * 0.6 = 76.8s
+    #
+    # Only scoping this to deploy because dont want to affect people's application that use the aws sdk.
+    #
+    # There is also additional rate backoff logic elsewhere, since this is only scoped to deploys.
+    #
+    # Useful links:
+    #   https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retry_errors.rb
+    #   https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html
+    #
+    def aws_config_update!
+      Aws.config.update(
+        retry_limit: 7, # default: 3
+        retry_base_delay: 0.6, # default: 0.3
+      )
     end
 
     def create_s3_event_buckets
@@ -100,6 +126,7 @@ module Jets::Commands
     end
 
     def find_stack(stack_name)
+      retries = 0
       resp = cfn.describe_stacks(stack_name: stack_name)
       resp.stacks.first
     rescue Aws::CloudFormation::Errors::ValidationError => e
@@ -108,6 +135,18 @@ module Jets::Commands
         nil
       else
         raise
+      end
+    rescue Aws::CloudFormation::Errors::Throttling => e
+      retries += 1
+      seconds = 2 ** retries
+
+      puts "WARN: find_stack #{e.class} #{e.message}".color(:yellow)
+      puts "Backing off and will retry in #{seconds} seconds."
+      sleep(seconds)
+      if seconds > 90 # 2 ** 6 is 64 so will give up after 6 retries
+        puts "Giving up after #{retries} retries"
+      else
+        retry
       end
     end
 

--- a/lib/jets/resource/api_gateway/rest_api/routes/change/base.rb
+++ b/lib/jets/resource/api_gateway/rest_api/routes/change/base.rb
@@ -17,6 +17,7 @@ class Jets::Resource::ApiGateway::RestApi::Routes::Change
         resp = apigateway.get_resources(
           rest_api_id: rest_api_id,
           position: position,
+          limit: 500, # default: 25 max: 500
         )
         resources += resp.items
         position = resp.position
@@ -57,11 +58,27 @@ class Jets::Resource::ApiGateway::RestApi::Routes::Change
     end
 
     def method_uri(resource_id, http_method)
-      resp = apigateway.get_method(
-        rest_api_id: rest_api_id,
-        resource_id: resource_id,
-        http_method: http_method
-      )
+      # https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html
+      retries = 0
+      begin
+        resp = apigateway.get_method(
+          rest_api_id: rest_api_id,
+          resource_id: resource_id,
+          http_method: http_method
+        )
+      rescue Aws::APIGateway::Errors::TooManyRequestsException => e
+        retries += 1
+        seconds = 2 ** retries
+
+        puts "WARN: method_uri #{e.class} #{e.message}".color(:yellow)
+        puts "Backing off and will retry in #{seconds} seconds."
+        sleep(seconds)
+        if seconds > 90 # 2 ** 6 is 64 so will give up after 6 retries
+          puts "Giving up after #{retries} retries"
+        else
+          retry
+        end
+      end
       resp.method_integration.uri
     end
 


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

With larger apps, deploys can fail from [AWS rate limiting](https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html). This adds some logic to handle it.

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
