### PR TITLE
stagger deploy option

### DIFF
--- a/docs/_docs/extras/deploy-stagger.md
+++ b/docs/_docs/extras/deploy-stagger.md
@@ -1,0 +1,31 @@
+---
+title: Deploy Stagger Option
+nav_order: 71
+---
+
+## Overview
+
+For large Jets applications, you may see this error during deployment.
+
+> Your request has been throttled by EC2, please make sure you have enough API rate limit. EC2 Error Code: RequestLimitExceeded. EC2 Error Message: Request limit exceeded. (Service: AWSLambdaInternal; Status Code: 400; Error Code: InvalidParameterValueException; Request ID: ea231a7b-cc32-42fe-8584-e78751cbea85)
+
+This error indicates that AWS has wisely established internal rate limits for its Lambda service to call the EC2 service. It means that Lambda is hitting its internal rate limit for calling EC2.
+
+In other words, your Jets application is creating so many Lambda functions in parallel that it is hitting internal AWS Lambda EC2 rate limits.
+
+Other users have [reported](https://forums.aws.amazon.com/thread.jspa?threadID=240384) running into this limit intermittently: [Rate Limit Exceeded?](https://community.rubyonjets.com/t/rate-limit-exceeded/257)  Interestingly, testing a Jets application with over 200 Lambda functions was not enough to trigger this internal rate limit.  So the application has to be quite large to trigger this limit.  This limit may also vary between accounts and region.  There does not seem to be any official guidance from AWS around this limit.
+
+## Stagger Options
+
+Jets supports a "stagger" deploy option to help reduce the rate at which Lambda functions are created in parallel.  It can be turned it on in `config/application.rb`:
+
+```ruby
+config.deploy.stagger.enabled = true  # default is false
+config.deploy.stagger.batch_size = 10 # default is 10
+```
+
+Normally, your Jets code gets translated to CloudFormation nested stacks that get created in parallel.  The stagger options tell CloudFormation to create the stacks serially instead.  Roughly speaking, if your Jets application generates 50 nested stacks, this results in 5 total batches each with 10 stacks. The stagger option intentionally slows down the deploy.
+
+Configuring these settings may help you to stay under this rate limit.  The settings can be tuned for your application.
+
+{% include prev_next.md %}

--- a/docs/_includes/subnav.html
+++ b/docs/_includes/subnav.html
@@ -109,6 +109,7 @@
         <li><a href="{% link _docs/extras/blue-green-deployment.md %}">Blue-Green Deployment</a></li>
         <li><a href="{% link _docs/extras/rake-tasks.md %}">Rake Tasks</a></li>
         <li><a href="{% link _docs/extras/codebuild.md %}">Continuous Integration</a></li>
+        <li><a href="{% link _docs/extras/deploy-stagger.md %}">Deploy Stagger</a></li>
         <li><a href="{% link _docs/extras/upgrading.md %}">Upgrading Guide</a></li>
       </ul>
     </li>

--- a/lib/jets/application/defaults.rb
+++ b/lib/jets/application/defaults.rb
@@ -147,6 +147,11 @@ class Jets::Application
       config.controllers = ActiveSupport::OrderedOptions.new
       config.controllers.default_protect_from_forgery = nil
 
+      config.deploy = ActiveSupport::OrderedOptions.new
+      config.deploy.stagger = ActiveSupport::OrderedOptions.new
+      config.deploy.stagger.enabled = false
+      config.deploy.stagger.batch_size = 10
+
       config
     end
 

--- a/lib/jets/aws_info.rb
+++ b/lib/jets/aws_info.rb
@@ -55,7 +55,7 @@ module Jets
       ENV['AWS_REGION'] ||= region
       begin
         sts.get_caller_identity.account
-      rescue Aws::Errors::MissingCredentialsError
+      rescue Aws::Errors::MissingCredentialsError, Aws::Errors::NoSuchEndpointError
         puts "INFO: You're missing AWS credentials. Only local services are currently available"
       end
     end

--- a/lib/jets/cfn/builders/base_child_builder.rb
+++ b/lib/jets/cfn/builders/base_child_builder.rb
@@ -35,7 +35,6 @@ module Jets::Cfn::Builders
 
     def depends_on_params
       return {} unless @app_class.depends_on
-
       depends = Jets::Stack::Depends.new(@app_class.depends_on)
       depends.params
     end

--- a/lib/jets/cfn/builders/parent_builder.rb
+++ b/lib/jets/cfn/builders/parent_builder.rb
@@ -4,6 +4,7 @@ module Jets::Cfn::Builders
   class ParentBuilder
     include Interface
     include Jets::AwsServices
+    include Stagger
 
     def initialize(options={})
       @options = options
@@ -68,6 +69,7 @@ module Jets::Cfn::Builders
 
     def add_app_class_stack(path)
       resource = Jets::Resource::ChildStack::AppClass.new(@options[:s3_bucket], path: path)
+      add_stagger(resource)
       add_child_resources(resource)
     end
 

--- a/lib/jets/cfn/builders/parent_builder/stagger.rb
+++ b/lib/jets/cfn/builders/parent_builder/stagger.rb
@@ -1,0 +1,34 @@
+class Jets::Cfn::Builders::ParentBuilder
+  module Stagger
+    def add_stagger(resource)
+      batch_size = stagger_batch_size # shorter convenience variable
+      return if !stagger_enabled || batch_size.nil? || batch_size == 0
+
+      # initialize all here to keep logic together
+      @previous_stacks ||= []
+      @added_count ||= 0
+
+      if @previous_stacks.size >= batch_size
+        at_boundary = @added_count % batch_size == 0
+        if at_boundary
+          @left = @added_count - batch_size
+          @right = @left + batch_size - 1
+        end
+        previous_stack_batch = @previous_stacks[@left..@right]
+        resource.add_stagger_depends_on(previous_stack_batch)
+      end
+
+      @added_count += 1
+      @previous_stacks << resource
+    end
+
+    def stagger_batch_size
+      Jets.config.deploy.stagger.batch_size
+    end
+
+    # for spec-ing
+    def stagger_enabled
+      Jets.config.deploy.stagger.enabled
+    end
+  end
+end

--- a/lib/jets/lambda/functions.rb
+++ b/lib/jets/lambda/functions.rb
@@ -29,6 +29,11 @@ module Jets::Lambda
         super
         self.subclasses << base if base.name
       end
+
+      # Needed for depends_on. Got added due to stagger logic.
+      def output_keys
+        []
+      end
     end
   end
 end

--- a/lib/jets/resource/child_stack/app_class.rb
+++ b/lib/jets/resource/child_stack/app_class.rb
@@ -21,26 +21,18 @@ module Jets::Resource::ChildStack
           }
         }
       }
-      defintion[logical_id][:depends_on] = depends_on if depends_on
+      defintion[logical_id][:depends_on] = depends.stack_list if depends
       defintion
     end
 
-    def depends_on
+    def depends
       return if all_depends_on.empty?
-      depends = Jets::Stack::Depends.new(all_depends_on)
-      depends.stack_list
+      Jets::Stack::Depends.new(all_depends_on)
     end
-
-    def depends_on_params
-      return if all_depends_on.empty?
-      depends = Jets::Stack::Depends.new(all_depends_on)
-      depends.params
-    end
+    memoize :depends
 
     # Always returns an Array, could be empty
     def all_depends_on
-      return [] if current_app_class.depends_on.nil? && @stagger_depends_on.nil?
-
       depends_on = current_app_class.depends_on || [] # contains Depends::Items
       stagger_depends_on = @stagger_depends_on  || [] # contains Depends::Items
       depends_on + stagger_depends_on
@@ -62,7 +54,7 @@ module Jets::Resource::ChildStack
     def parameters
       common = self.class.common_parameters
       common.merge!(controller_params) if controller?
-      common.merge!(depends_on_params) if depends_on
+      common.merge!(depends.params) if depends
       common
     end
 

--- a/lib/jets/stack/depends.rb
+++ b/lib/jets/stack/depends.rb
@@ -1,15 +1,15 @@
 class Jets::Stack
   class Depends
     def initialize(items)
-      @items = items
+      @items = items # Jets::Stack::Depends::Item - has stack and options properties
     end
 
     def params
       result = {}
       @items.each do |item|
-        logical_id = item.stack.to_s.camelize # logical_id
-        dependency_outputs(logical_id).each do |output|
-          dependency_class = logical_id.to_s.camelize
+        class_name = item.class_name
+        dependency_outputs(class_name).each do |output|
+          dependency_class = class_name.to_s.camelize
           output_key = item.options[:class_prefix] ?
             "#{dependency_class}#{output}" : # already camelized
             output
@@ -21,14 +21,14 @@ class Jets::Stack
       result
     end
 
+    # Returns CloudFormation template logical ids
     def stack_list
-      @items.map do |item|
-        item.stack.to_s.camelize # logical_id # logical_id
-      end
+      @items.map(&:logical_id)
     end
 
-    def dependency_outputs(logical_id)
-      logical_id.to_s.camelize.constantize.output_keys
+  private
+    def dependency_outputs(class_name)
+      class_name.to_s.camelize.constantize.output_keys
     end
   end
 end

--- a/lib/jets/stack/depends/item.rb
+++ b/lib/jets/stack/depends/item.rb
@@ -1,9 +1,26 @@
+# Usage examples:
+#
+#   Jets::Stack::Depends::Item.new(:custom)
+#   Jets::Stack::Depends::Item.new(:custom, :alert)
+#   Jets::Stack::Depends::Item.new(:custom, class_prefix: true)
+#   Jets::Stack::Depends::Item.new(:custom, :alert, class_prefix: true)
+#
+# The Jets::Stack::Depends#params uses the options to determine if the class prefix should be added.
+#
 class Jets::Stack::Depends
   class Item
     attr_reader :stack, :options
     def initialize(stack, options={})
-      @stack = stack
+      @stack = stack # should be underscore format. IE: admin/posts_controller
       @options = options
+    end
+
+    def logical_id
+      @stack.to_s.gsub('::','').gsub('/','_').camelize
+    end
+
+    def class_name
+      @stack.to_s.camelize
     end
   end
 end

--- a/spec/lib/jets/cfn/builders/parent_builder/stagger_spec.rb
+++ b/spec/lib/jets/cfn/builders/parent_builder/stagger_spec.rb
@@ -1,0 +1,154 @@
+module Staggerable
+  class Stack
+    attr_reader :stagger_depends_on, :name
+    def initialize(name, options={})
+      @name = name
+      @stagger_depends_on = []
+    end
+
+    def add_stagger_depends_on(*batch)
+      @stagger_depends_on = batch.flatten.map(&:name)
+    end
+  end
+
+  class Parent
+    include Jets::Cfn::Builders::ParentBuilder::Stagger
+    # override module method `stagger_enabled` in spec to always enable
+    def stagger_enabled
+      true
+    end
+
+    def initialize
+      @list = []
+    end
+
+    def build(*stacks)
+      stacks.flatten.each do |name|
+        add_stack(name)
+      end
+      @list
+    end
+
+    def add_stack(name)
+      current_stack = Stack.new(name)
+      add_stagger(current_stack)
+      @list << current_stack
+    end
+  end
+end
+
+describe Jets::Cfn::Builders::ParentBuilder::Stagger do
+  let(:builder) do
+    parent = Staggerable::Parent.new
+    allow(parent).to receive(:stagger_batch_size).and_return(batch_size)
+    parent
+  end
+
+  context "even number of resources in" do
+    let(:resources) { (1..6).map { |i| "stack#{i}" } }
+    context "batches of 0" do
+      let(:batch_size) { 0 }
+      it "ok" do
+        list = builder.build(resources)
+        list.each do |stack|
+          expect(stack.stagger_depends_on).to eq([])
+        end
+      end
+    end
+
+    context "batches of 2" do
+      let(:batch_size) { 2 }
+      it "ok" do
+        list = builder.build(resources)
+        expect(list[0].stagger_depends_on).to eq([])
+        expect(list[1].stagger_depends_on).to eq([])
+        expect(list[2].stagger_depends_on).to eq(%w[stack1 stack2])
+        expect(list[3].stagger_depends_on).to eq(%w[stack1 stack2])
+        expect(list[4].stagger_depends_on).to eq(%w[stack3 stack4])
+        expect(list[5].stagger_depends_on).to eq(%w[stack3 stack4])
+      end
+    end
+
+    context "batches of 3" do
+      let(:batch_size) { 3 }
+      it "ok" do
+        list = builder.build(resources)
+        expect(list[0].stagger_depends_on).to eq([])
+        expect(list[1].stagger_depends_on).to eq([])
+        expect(list[2].stagger_depends_on).to eq([])
+        expect(list[3].stagger_depends_on).to eq(%w[stack1 stack2 stack3])
+        expect(list[4].stagger_depends_on).to eq(%w[stack1 stack2 stack3])
+        expect(list[5].stagger_depends_on).to eq(%w[stack1 stack2 stack3])
+      end
+    end
+
+    context "batches of 4" do
+      let(:batch_size) { 4 }
+      it "ok" do
+        list = builder.build(resources)
+        expect(list[0].stagger_depends_on).to eq([])
+        expect(list[1].stagger_depends_on).to eq([])
+        expect(list[2].stagger_depends_on).to eq([])
+        expect(list[3].stagger_depends_on).to eq([])
+        expect(list[4].stagger_depends_on).to eq(%w[stack1 stack2 stack3 stack4])
+        expect(list[5].stagger_depends_on).to eq(%w[stack1 stack2 stack3 stack4])
+      end
+    end
+  end
+
+  context "odd number of resources in" do
+    let(:resources) { (1..7).map { |i| "stack#{i}" } }
+    context "batches of 2" do
+      let(:batch_size) { 2 }
+      it "ok" do
+        list = builder.build(resources)
+        expect(list[0].stagger_depends_on).to eq([])
+        expect(list[1].stagger_depends_on).to eq([])
+        expect(list[2].stagger_depends_on).to eq(%w[stack1 stack2])
+        expect(list[3].stagger_depends_on).to eq(%w[stack1 stack2])
+        expect(list[4].stagger_depends_on).to eq(%w[stack3 stack4])
+        expect(list[5].stagger_depends_on).to eq(%w[stack3 stack4])
+        expect(list[6].stagger_depends_on).to eq(%w[stack5 stack6])
+      end
+    end
+
+    context "batches of 3" do
+      let(:batch_size) { 3 }
+      it "ok" do
+        list = builder.build(resources)
+        expect(list[0].stagger_depends_on).to eq([])
+        expect(list[1].stagger_depends_on).to eq([])
+        expect(list[2].stagger_depends_on).to eq([])
+        expect(list[3].stagger_depends_on).to eq(%w[stack1 stack2 stack3])
+        expect(list[4].stagger_depends_on).to eq(%w[stack1 stack2 stack3])
+        expect(list[5].stagger_depends_on).to eq(%w[stack1 stack2 stack3])
+        expect(list[6].stagger_depends_on).to eq(%w[stack4 stack5 stack6])
+      end
+    end
+
+    context "batches of 4" do
+      let(:batch_size) { 4 }
+      it "ok" do
+        list = builder.build(resources)
+        expect(list[0].stagger_depends_on).to eq([])
+        expect(list[1].stagger_depends_on).to eq([])
+        expect(list[2].stagger_depends_on).to eq([])
+        expect(list[3].stagger_depends_on).to eq([])
+        expect(list[4].stagger_depends_on).to eq(%w[stack1 stack2 stack3 stack4])
+        expect(list[5].stagger_depends_on).to eq(%w[stack1 stack2 stack3 stack4])
+        expect(list[6].stagger_depends_on).to eq(%w[stack1 stack2 stack3 stack4])
+      end
+    end
+  end
+
+  context "0 number of resources in" do
+    let(:resources) { [] }
+    context "batches of 2" do
+      let(:batch_size) { 2 }
+      it "ok" do
+        list = builder.build(resources)
+        expect(list).to eq([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
* add stagger to slow down deploy if needed
* docs: config.deploy.stagger options
* specs: stagger_spec.rb

This is a 🙋‍♂️ feature or enhancement.
This is a 🧐 documentation change.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Users with rather larger Jets applications (hundreds of lambda functions) are running into internal AWS Lambda -> EC2 Rate limits.   This adds stagger options which slow down the deploy to mitigate running up against the rate limit.  Example:

config/application.rb:

```ruby
config.deploy.stagger.enabled = true  # default is false
config.deploy.stagger.batch_size = 10 # default is 10
```

Interestingly, tested with a Jets application with more than 200 Lambda functions and was unable to trigger the internal Lambda rate limit. 

<img width="1375" alt="lambda-200-functions" src="https://user-images.githubusercontent.com/4085/64476985-98e11000-d131-11e9-8b1f-56c79d33c5d4.png">

Others have reported running into this though 🧐

## Context

https://community.rubyonjets.com/t/rate-limit-exceeded/257

