### PR TITLE
fix copy ruby version

### DIFF
--- a/lib/jets/builders/code_builder.rb
+++ b/lib/jets/builders/code_builder.rb
@@ -372,9 +372,9 @@ module Jets::Builders
     end
 
     def copy_ruby_version_file
-      return unless File.exists?(".ruby-version")
-
-      FileUtils.cp_r(Jets.root.join(".ruby-version"), build_area)
+      ruby_version_path = Jets.root.join(".ruby-version")
+      return unless File.exists?(ruby_version_path)
+      FileUtils.cp_r(ruby_version_path, build_area)
     end
 
     def ruby_version_supported?


### PR DESCRIPTION
This is a 🐞 bug fix.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fixes edge case for Jets Afterburner deploy mode. If the rails project has a `.ruby-version` then the deploy fails. This fixes it.

## Context

Report: #363

Related: #317 #316 #313

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
