### PR TITLE
Use unicode for encoding when using postgres.

### DIFF
--- a/docs/_docs/crud-html-activerecord.md
+++ b/docs/_docs/crud-html-activerecord.md
@@ -72,7 +72,7 @@ In the next step, we'll update the .env.development and set the local database c
 ```yaml
 default: &default
   adapter: postgresql
-  encoding: utf8mb4
+  encoding: unicode
   pool: <%= ENV["DB_POOL"] || 5  %>
   database: <%= ENV['DB_NAME'] || 'demo_dev' %>
   username: <%= ENV['DB_USER'] || ENV['USER'] %>

--- a/docs/_docs/crud-json-activerecord.md
+++ b/docs/_docs/crud-json-activerecord.md
@@ -66,7 +66,7 @@ In the next step, we'll update the .env.development and set the local database c
 ```yaml
 default: &default
   adapter: postgresql
-  encoding: utf8mb4
+  encoding: unicode
   pool: <%= ENV["DB_POOL"] || 5  %>
   database: <%= ENV['DB_NAME'] || 'demo_dev' %>
   username: <%= ENV['DB_USER'] || ENV['USER'] %>

--- a/lib/jets/commands/import/templates/config/database.yml
+++ b/lib/jets/commands/import/templates/config/database.yml
@@ -1,6 +1,10 @@
 default: &default
   adapter:  <%= @adapter %>
+<% if @adapter == 'postgresql' -%>
+  encoding: unicode
+<% else -%>
   encoding: utf8mb4
+<% end -%>
   pool: <%%= ENV["DB_POOL"] || 5  %>
   database: <%%= ENV['DB_NAME'] || '<%= @database_development %>' %>
 <% if @adapter == 'postgresql' -%>

--- a/lib/jets/commands/templates/skeleton/config/database.yml.tt
+++ b/lib/jets/commands/templates/skeleton/config/database.yml.tt
@@ -1,10 +1,9 @@
 default: &default
   adapter: <%= @database == 'mysql' ? 'mysql2' : 'postgresql' %>
-  encoding: utf8mb4
+  encoding: <%= @database == 'mysql' ? 'utf8mb4' : 'unicode' %>
   pool: <%%= ENV["DB_POOL"] || 5  %>
   database: <%%= ENV['DB_NAME'] || '<%= @project_name %>_development' %>
 <% if @database == 'mysql' -%>
-  encoding: utf8mb4
   username: <%%= ENV['DB_USER'] || 'root' %>
 <% else -%>
   username: <%%= ENV['DB_USER'] || ENV['USER'] %>


### PR DESCRIPTION
This is a 🐞 bug fix.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

This pull changes the encoding for postgres database configurations. By default the utf8mb4 encoding would be used for both mysql and postgres. This is incorrect as postgres returned an error upon trying to use utf8mb4 as encoding.
Rails itself also using the unicode encoding for postgres, see: https://github.com/rails/rails/blob/235eb91bad58ab18b45aa36fa3a1ebedfe1c4879/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt.

I couldn't find where the `jets new` command is being tested so not sure if tests should still be added for this. If so I could use some guidance on that.

## Context

This is not related to any other issue. Upon creating a new jets project using postgres I received the following error:

`PG::Error: ERROR:  invalid value for parameter "client_encoding": "utf8mb4"`

## Version Changes

This is a bugfix so a minor version change would suffice (e.g. 2.2.2).
