### PR TITLE
fix to allow using only cognito authorizers

### DIFF
--- a/lib/jets/authorizer/dsl.rb
+++ b/lib/jets/authorizer/dsl.rb
@@ -54,6 +54,10 @@ module Jets::Authorizer
       def cognito_authorizers
         all_cognito_authorizers.values
       end
+
+      def build?
+        !tasks.empty? || !all_cognito_authorizers.empty?
+      end
     end
 
     included do


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fix a bug when only cognito authorizers are being used w/o any lambda authorizers.

## Context

https://community.rubyonjets.com/t/deploying-is-failing-with-cognito-authorizer/266

## Version Changes

Patch