### PR TITLE
use JETS_TEST env var instead and favor Jets.env.test? method

### DIFF
--- a/lib/jets/aws_info.rb
+++ b/lib/jets/aws_info.rb
@@ -5,7 +5,7 @@ module Jets
     include AwsServices
 
     def region
-      return 'us-east-1' if test?
+      return 'us-east-1' if Jets.env.test?
 
       return ENV['JETS_AWS_REGION'] if ENV['JETS_AWS_REGION'] # highest precedence
       return ENV['AWS_REGION'] if ENV['AWS_REGION']
@@ -48,7 +48,7 @@ module Jets
 
     # aws sts get-caller-identity
     def account
-      return '123456789' if test?
+      return '123456789' if Jets.env.test?
       return ENV['JETS_AWS_ACCOUNT'] if ENV['JETS_AWS_ACCOUNT']
 
       # ensure region set, required for sts.get_caller_identity.account to work
@@ -70,7 +70,7 @@ module Jets
     BUCKET_DOES_NOT_YET_EXIST = "bucket-does-not-yet-exist" # use const to save from misspellings
     @@s3_bucket = BUCKET_DOES_NOT_YET_EXIST
     def s3_bucket
-      return "fake-test-s3-bucket" if ENV['TEST']
+      return "fake-test-s3-bucket" if Jets.env.test?
       return @@s3_bucket unless @@s3_bucket == BUCKET_DOES_NOT_YET_EXIST
 
       resp = cfn.describe_stacks(stack_name: Jets::Naming.parent_stack_name)
@@ -88,10 +88,6 @@ module Jets
       # Rescuing all exceptions in case there are other exceptions dont know about yet
       # Here are the known ones: Aws::CloudFormation::Errors::ValidationError, Aws::CloudFormation::Errors::InvalidClientTokenId
       BUCKET_DOES_NOT_YET_EXIST
-    end
-
-    def test?
-      ENV['TEST'] || Jets.env.test?
     end
 
     private

--- a/lib/jets/aws_services/stack_status.rb
+++ b/lib/jets/aws_services/stack_status.rb
@@ -3,7 +3,7 @@ module Jets::AwsServices
     # Only cache if it is true because the initial deploy checks live status until a stack exists.
     @@stack_exists_cache = [] # helps with CloudFormation rate limit
     def stack_exists?(stack_name)
-      return false if ENV['TEST']
+      return false if Jets.env.test?
       return true if ENV['JETS_BUILD_NO_INTERNET']
       return true if @@stack_exists_cache.include?(stack_name)
 

--- a/lib/jets/builders/code_size.rb
+++ b/lib/jets/builders/code_size.rb
@@ -36,7 +36,7 @@ module Jets::Builders
       say "Total Package: #{megabytes(total_size)}"
       say "Over limit by: #{megabytes(overlimit)}"
       say "Sometimes blowing away the /tmp/jets cache will reduce the size: rm -rf /tmp/jets"
-      # sh "du -kcsh #{stage_area}/*" unless ENV['TEST'] # uncomment to debug
+      # sh "du -kcsh #{stage_area}/*" unless Jets.env.test? # uncomment to debug
     end
 
     def compute_size(path)
@@ -51,7 +51,7 @@ module Jets::Builders
     end
 
     def say(message)
-      puts message unless ENV['TEST']
+      puts message unless Jets.env.test?
     end
   end
 end

--- a/lib/jets/cfn/status.rb
+++ b/lib/jets/cfn/status.rb
@@ -96,7 +96,7 @@ module Jets::Cfn
       end
 
       return if final
-      sleep 5 unless ENV['TEST']
+      sleep 5 unless Jets.env.test?
       refresh_events
     end
 

--- a/lib/jets/commands/dynamodb/migrator.rb
+++ b/lib/jets/commands/dynamodb/migrator.rb
@@ -20,7 +20,7 @@ class Jets::Commands::Dynamodb::Migrator
     path = "#{Jets.root}/#{@path}"
     unless File.exist?(path)
       puts "Unable to find the migration file: #{path}"
-      exit 1 unless ENV['TEST']
+      exit 1 unless Jets.env.test?
     end
 
     require path

--- a/lib/jets/commands/templates/skeleton/spec/spec_helper.rb.tt
+++ b/lib/jets/commands/templates/skeleton/spec/spec_helper.rb.tt
@@ -1,5 +1,5 @@
-ENV["TEST"] = "1"
-ENV["JETS_ENV"] ||= "test"
+ENV['JETS_TEST'] = "1"
+ENV['JETS_ENV'] ||= "test"
 # Ensures aws api never called. Fixture home folder does not contain ~/.aws/credentails
 ENV['HOME'] = "spec/fixtures/home"
 

--- a/lib/jets/controller/forgery_protection.rb
+++ b/lib/jets/controller/forgery_protection.rb
@@ -30,7 +30,7 @@ class Jets::Controller
 
     # Instance methods
     def verify_authenticity_token
-      return true if ENV['TEST'] || request.get? || request.head?
+      return true if Jets.env.test? || request.get? || request.head?
 
       token = session[:authenticity_token]
       verified = !token.nil? && (token == params[:authenticity_token] || token == request.headers["x-csrf-token"])

--- a/lib/jets/controller/middleware/local.rb
+++ b/lib/jets/controller/middleware/local.rb
@@ -69,7 +69,7 @@ module Jets::Controller::Middleware
     end
 
     def on_aws?(env)
-      return false if ENV['TEST'] # usually with test we're passing in full API Gateway fixtures with the HTTP_X_AMZN_TRACE_ID
+      return false if Jets.env.test? # usually with test we're passing in full API Gateway fixtures with the HTTP_X_AMZN_TRACE_ID
       on_cloud9 = !!(env['HTTP_HOST'] =~ /cloud9\..*\.amazonaws\.com/)
       !!env['HTTP_X_AMZN_TRACE_ID'] && !on_cloud9
     end

--- a/lib/jets/erb.rb
+++ b/lib/jets/erb.rb
@@ -38,7 +38,7 @@ class Jets::Erb
             printf("%#{spacing}d %s\n", line_number, line_content)
           end
         end
-        exit 1 unless ENV['TEST']
+        exit 1 unless Jets.env.test?
       end
     end
 

--- a/lib/jets/internal/app/jobs/jets/preheat_job.rb
+++ b/lib/jets/internal/app/jobs/jets/preheat_job.rb
@@ -34,7 +34,7 @@ class Jets::PreheatJob < ApplicationJob
         function_name = "jets-preheat_job-warm"
         event_json = JSON.dump(event)
         options = call_options(event[:quiet])
-        Jets::Commands::Call.new(function_name, event_json, options).run unless ENV['TEST']
+        Jets::Commands::Call.new(function_name, event_json, options).run unless Jets.env.test?
       end
     end
     threads.each { |t| t.join }

--- a/lib/jets/preheat.rb
+++ b/lib/jets/preheat.rb
@@ -23,7 +23,7 @@ module Jets
 
     # Makes remote call to the Lambda function.
     def warm(function_name)
-      Jets::Commands::Call.new(function_name, '{"_prewarm": "1"}', @options).run unless ENV['TEST']
+      Jets::Commands::Call.new(function_name, '{"_prewarm": "1"}', @options).run unless Jets.env.test?
     end
 
     # Loop through all methods for each class and makes special prewarm call to each method.

--- a/lib/jets/processors/main_processor.rb
+++ b/lib/jets/processors/main_processor.rb
@@ -43,7 +43,7 @@ class Jets::Processors::MainProcessor
 
       result
     rescue Exception => e
-      unless ENV['TEST']
+      unless Jets.env.test?
         # Customize error message slightly so nodejs shim can process the
         # returned error message.
         # The "RubyError: " is a marker that the javascript shim scans for.

--- a/spec/fixtures/apps/franky/app/jobs/easy_job.rb
+++ b/spec/fixtures/apps/franky/app/jobs/easy_job.rb
@@ -1,7 +1,7 @@
 class EasyJob < ApplicationJob
   rate "1 day"
   def sleep
-    seconds = ENV['TEST'] ? 0 : 1
+    seconds = Jets.env.test? ? 0 : 1
     sleep seconds
     {done: "sleeping"}
   end

--- a/spec/fixtures/apps/franky/spec/spec_helper.rb
+++ b/spec/fixtures/apps/franky/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-ENV["TEST"] = "1"
+ENV['JETS_TEST'] = "1"
 # Ensures aws api never called. Fixture home folder does not contain ~/.aws/credentails
 ENV['HOME'] = "spec/fixtures/home"
 ENV['JETS_ENV'] = "test"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-ENV["TEST"] = "1"
+ENV["JETS_TEST"] = "1"
 ENV["JETS_ENV"] = "test"
 ENV["JETS_ROOT"] = "./spec/fixtures/apps/franky"
 # Ensures aws api never called. Fixture home folder does not contain ~/.aws/credentails


### PR DESCRIPTION
This is a 🙋‍♂️ feature or enhancement.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

* use `JETS_TEST=1` env var instead of `TEST=1` for specs
* favor Jets.env.test? method in code

