### PR TITLE
associated resources support for controllers

### DIFF
--- a/lib/jets/cfn/builders/controller_builder.rb
+++ b/lib/jets/cfn/builders/controller_builder.rb
@@ -11,6 +11,7 @@ module Jets::Cfn::Builders
       add_api_gateway_parameters
       add_functions
       add_routes
+      add_resources
     end
 
     def add_api_gateway_parameters


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Allow creation of [Assocaited Resources](https://rubyonjets.com/docs/function-resources/) within controllers.

## Context

Gitter question

## Version Changes

patch