### PR TITLE
add jets and code version to parent template description

### DIFF
--- a/lib/jets/cfn/builders/interface.rb
+++ b/lib/jets/cfn/builders/interface.rb
@@ -50,6 +50,10 @@ module Jets::Cfn::Builders
       results.join("\n") + "\n"
     end
 
+    def add_description(desc)
+      @template[:Description] = desc
+    end
+
     def add_parameters(attributes)
       attributes.each do |name,value|
         add_parameter(name.to_s.camelize, Description: value)

--- a/lib/jets/cfn/builders/parent_builder.rb
+++ b/lib/jets/cfn/builders/parent_builder.rb
@@ -23,6 +23,8 @@ module Jets::Cfn::Builders
     end
 
     def build_minimal_resources
+      add_description("Jets: #{Jets.version} Code: #{Util::Source.version}")
+
       # Initial s3 bucket, used to store code zipfile and templates Jets generates
       resource = Jets::Resource::S3::Bucket.new(logical_id: "s3_bucket")
       add_resource(resource)

--- a/lib/jets/cfn/builders/util/source.rb
+++ b/lib/jets/cfn/builders/util/source.rb
@@ -1,0 +1,21 @@
+module Jets::Cfn::Builders::Util
+  class Source
+    class << self
+      def version
+        return '' unless git_installed?
+        sha = sh "git rev-parse HEAD 2>/dev/null"
+        return '' if sha == ''  # if its not a git repo, it'll be an empty string
+        sha[0..7]
+      end
+
+    private
+      def git_installed?
+        system("type git > /dev/null 2>&1")
+      end
+
+      def sh(command)
+        `#{command}`.strip
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Adds Jets version and Code version (git sha) to parent stack description. 

Only supports git right now. It's a start.

## Version Changes

Patch