### PR TITLE
Fix issue templateBody failed to satisfy constraint: Member must have length less than or equal to 51200

### DIFF
--- a/lib/jets/cfn/ship.rb
+++ b/lib/jets/cfn/ship.rb
@@ -80,7 +80,7 @@ module Jets::Cfn
     end
 
     def template
-      @template ||= Template.new(Jets::Naming.parent_template_path, @options)
+      @template ||= TemplateSource.new(Jets::Naming.parent_template_path, @options)
     end
 
     # check for /(_COMPLETE|_FAILED)$/ status

--- a/lib/jets/cfn/ship.rb
+++ b/lib/jets/cfn/ship.rb
@@ -6,7 +6,6 @@ module Jets::Cfn
     def initialize(options)
       @options = options
       @parent_stack_name = Jets::Naming.parent_stack_name
-      @template_path = Jets::Naming.parent_template_path
     end
 
     def run
@@ -75,10 +74,13 @@ module Jets::Cfn
     def stack_options
       {
         stack_name: @parent_stack_name,
-        template_body: IO.read(@template_path),
         capabilities: capabilities, # ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM"]
         # disable_rollback: !@options[:rollback],
-      }
+      }.merge!(template.to_h)
+    end
+
+    def template
+      @template ||= Template.new(Jets::Naming.parent_template_path, @options)
     end
 
     # check for /(_COMPLETE|_FAILED)$/ status

--- a/lib/jets/cfn/template.rb
+++ b/lib/jets/cfn/template.rb
@@ -1,0 +1,56 @@
+module Jets::Cfn
+  class Template
+    include Jets::AwsServices
+
+    attr_reader :path
+
+    def inilialize(path, options)
+      @path = path
+      @options = options
+    end
+
+    def body
+      @body ||= IO.read(path)
+    end
+
+    def url
+      @url ||= upload_file_to_s3
+    end
+
+    def to_h
+      if upload_to_s3?
+        from_s3
+      else
+        from_path
+      end
+    end
+
+    private
+
+    def upload_to_s3?
+      bucket_name.present?
+    end
+
+    def bucket_name
+      @options[:s3_bucket]
+    end
+
+    def from_s3
+      {
+        template_url: url
+      }
+    end
+
+    def from_path
+      {
+        template_body: body
+      }
+    end
+
+    def upload_file_to_s3
+      key = "jets/cfn-templates/#{File.basename(path)}"
+      obj = s3_resource.bucket(bucket_name).object(key)
+      obj.upload_file(path)
+    end
+  end
+end

--- a/lib/jets/cfn/template_source.rb
+++ b/lib/jets/cfn/template_source.rb
@@ -31,10 +31,6 @@ module Jets::Cfn
       bucket_name.present?
     end
 
-    def bucket_name
-      @options[:s3_bucket]
-    end
-
     def from_s3
       {
         template_url: url
@@ -48,9 +44,18 @@ module Jets::Cfn
     end
 
     def upload_file_to_s3
-      key = "jets/cfn-templates/#{File.basename(path)}"
-      obj = s3_resource.bucket(bucket_name).object(key)
+      obj = s3_resource.bucket(bucket_name).object(s3_key)
       obj.upload_file(path)
+
+      "s3://#{bucket_name}/#{s3_key}"
+    end
+
+    def bucket_name
+      @options[:s3_bucket]
+    end
+
+    def s3_key
+      @s3_key ||= "jets/cfn-templates/#{File.basename(path)}"
     end
   end
 end

--- a/lib/jets/cfn/template_source.rb
+++ b/lib/jets/cfn/template_source.rb
@@ -4,7 +4,7 @@ module Jets::Cfn
 
     attr_reader :path
 
-    def inilialize(path, options)
+    def initialize(path, options)
       @path = path
       @options = options
     end

--- a/lib/jets/cfn/template_source.rb
+++ b/lib/jets/cfn/template_source.rb
@@ -1,5 +1,5 @@
 module Jets::Cfn
-  class Template
+  class TemplateSource
     include Jets::AwsServices
 
     attr_reader :path

--- a/lib/jets/cfn/template_source.rb
+++ b/lib/jets/cfn/template_source.rb
@@ -47,7 +47,7 @@ module Jets::Cfn
       obj = s3_resource.bucket(bucket_name).object(s3_key)
       obj.upload_file(path)
 
-      "s3://#{bucket_name}/#{s3_key}"
+      "https://s3.amazonaws.com/#{bucket_name}/#{s3_key}"
     end
 
     def bucket_name

--- a/spec/lib/jets/cfn/template_source_spec.rb
+++ b/spec/lib/jets/cfn/template_source_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+describe Jets::Cfn::TemplateSource do
+  let(:path) { '/tmp/test.txt' }
+  let(:template) do
+    described_class.new(path, s3_bucket: s3_backet)
+  end
+
+  context 'without s3_backet' do
+    let(:s3_backet) { nil }
+    let(:body) { 'long file body' }
+
+    it 'must read file from disk' do
+      expect(template).to receive(:body).and_return(body)
+
+      expect(template.to_h[:template_body]).to eq body
+    end
+  end
+
+  context 'with s3_backet' do
+    let(:s3_backet) { 'test' }
+    let(:url) { "https://s3.amazonaws.com/#{s3_backet}/test" }
+
+    it 'must upload file to s3' do
+      expect(template).to receive(:upload_file_to_s3).and_return(url)
+
+      expect(template.to_h[:template_url]).to eq url
+    end
+  end
+end


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Upload CloudFormation template to s3 bucket if a bucket present

## Context

Fix issue https://github.com/tongueroo/jets/issues/379

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

I think PATCH version can be applied
