### PR TITLE
dont bomb in TmpLoader when Jets.once called in simple function

### DIFF
--- a/lib/jets/tmp_loader.rb
+++ b/lib/jets/tmp_loader.rb
@@ -8,7 +8,7 @@ module Jets
 
     def initialize(yaml_path=nil)
       yaml_path ||= "#{Jets.root}/handlers/data.yml"
-      @data = YAML.load_file(yaml_path)
+      @data = YAML.load_file(yaml_path) if File.exist?(yaml_path)
       @s3_bucket = @data['s3_bucket']
       @rack_zip = @data['rack_zip']
     end


### PR DESCRIPTION
This is a 🐞 bug fix.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Allow `Jets.once` to be called in a [simple function](https://rubyonjets.com/docs/functions/) without bombing in the TmpLoader.

## Context

https://community.rubyonjets.com/t/accessing-jets-models-in-simple-functions/288/5

## Version Changes

Patch