### PR TITLE
remove .bundle/config instead of BUNDLE_IGNORE_CONFIG=1

### DIFF
--- a/lib/jets/builders/ruby_packager.rb
+++ b/lib/jets/builders/ruby_packager.rb
@@ -50,11 +50,19 @@ module Jets::Builders
       # Uncomment out to always remove the cache/vendor/gems to debug
       # FileUtils.rm_rf("#{cache_area}/vendor/gems")
 
+      # Remove .bundle folder so .bundle/config doesnt affect how Jets packages gems.
+      # Not using BUNDLE_IGNORE_CONFIG=1 to allow home ~/.bundle/config to affect bundling though.
+      # This is useful if you have private gems sources that require authentication. Example:
+      #
+      #    bundle config gems.myprivatesource.com user:pass
+      #
+
       require "bundler" # dynamically require bundler so user can use any bundler
       Bundler.with_clean_env do
         sh(
+          "rm -rf #{cache_area}/.bundle && " \
           "cd #{cache_area} && " \
-          "env BUNDLE_IGNORE_CONFIG=1 bundle install --path #{cache_area}/vendor/gems --without development test"
+          "env bundle install --path #{cache_area}/vendor/gems --without development test"
         )
       end
 


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Removing projects `.bundle` as part of jets deploy ruby packaging instead of global `BUNDLE_IGNORE_CONFIG=1`. 

This allows `~/.bundle/config` to be respected. 

This is useful if you have private gems sources that require authentication. Example:

    bundle config gems.myprivatesource.com user:pass

## Context

Was brought up in Gitter chat: https://gitter.im/tongueroo/jets (unsure how to link to specific post)

## Version Changes

Patch