### PR TITLE
Add AWS comprehend to AwsServices

### DIFF
--- a/jets.gemspec
+++ b/jets.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws-sdk-apigateway"
   spec.add_dependency "aws-sdk-cloudformation"
   spec.add_dependency "aws-sdk-cloudwatchlogs"
+  spec.add_dependency "aws-sdk-comprehend"
   spec.add_dependency "aws-sdk-dynamodb"
   spec.add_dependency "aws-sdk-kinesis"
   spec.add_dependency "aws-sdk-lambda"

--- a/lib/jets/aws_services.rb
+++ b/lib/jets/aws_services.rb
@@ -1,6 +1,7 @@
 require "aws-sdk-apigateway"
 require "aws-sdk-cloudformation"
 require "aws-sdk-cloudwatchlogs"
+require "aws-sdk-comprehend"
 require "aws-sdk-dynamodb"
 require "aws-sdk-lambda"
 require "aws-sdk-s3"
@@ -37,6 +38,11 @@ module Jets::AwsServices
     Aws::CloudWatchLogs::Client.new
   end
   global_memoize :logs
+
+  def comprehend
+    Aws::Comprehend::Client.new
+  end
+  global_memoize :comprehend
 
   def s3
     Aws::S3::Client.new


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

I've added [aws-sdk-comprehend](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/Comprehend.html) to the list of available AWS services (`AwsServices` module).