### PR TITLE
Add kinesis_stream dsl method.

### DIFF
--- a/lib/jets/stack/main/dsl/kinesis.rb
+++ b/lib/jets/stack/main/dsl/kinesis.rb
@@ -1,0 +1,15 @@
+module Jets::Stack::Main::Dsl
+  module Kinesis
+    def kinesis_stream(id, props={})
+      defaults = {
+        name: id,
+        shard_count: 1
+      }
+
+      props = defaults.merge(props)
+
+      resource(id, "AWS::Kinesis::Stream", props)
+      output(id)
+    end
+  end
+end


### PR DESCRIPTION
This is a 🙋‍♂️ feature or enhancement.

- [ ] I've added tests (if it's a bug, feature or enhancement)

Couldn't find test for the other DSL methods... but maybe I'm wrong?

- [ ] I've adjusted the documentation (if it's a feature or enhancement)

I couldn't find a place where the other DSL methods are documented. Please point me to that if that exists and I'll be happy to help.

- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

This allows us to easily add kinesis stream to a project.

## Context

We were just trying jets for the first time and we would like to have a quick way to create a kinesis stream.

## Version Changes

minor
