### PR TITLE
Fix command execution error by missing dependency

### DIFF
--- a/jets.gemspec
+++ b/jets.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws-sdk-sqs"
   spec.add_dependency "aws-sdk-ssm"
   spec.add_dependency "cfn_camelizer"
+  spec.add_dependency "cfn-status"
   spec.add_dependency "cfnresponse"
   spec.add_dependency "dotenv"
   spec.add_dependency "gems" # jets-gems dependency

--- a/lib/jets.rb
+++ b/lib/jets.rb
@@ -16,7 +16,7 @@ require "rainbow/ext/string"
 gem_root = File.dirname(__dir__)
 $:.unshift("#{gem_root}/lib")
 $:.unshift("#{gem_root}/vendor/cfn-status/lib")
-require "cfn_status"
+require "cfn/status"
 
 require "jets/autoloaders"
 Jets::Autoloaders.log! if ENV["JETS_AUTOLOAD_LOG"]

--- a/lib/jets/cfn/status.rb
+++ b/lib/jets/cfn/status.rb
@@ -1,7 +1,7 @@
-require 'cfn_status'
+require 'cfn/status'
 
 module Jets::Cfn
-  class Status < CfnStatus
+  class Status < Cfn::Status
     def initialize(options={})
       @stack_name = Jets::Naming.parent_stack_name
       super(@stack_name, options)


### PR DESCRIPTION
 This is a 🐞 bug fix.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [-] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

I've just tested locally jets command and hit the following error:

```
shinya@shinya-Galago-Pro:~/workspace/jets$ exe/jets help
Traceback (most recent call last):
        8: from exe/jets:13:in `<main>'
        7: from /home/shinya/.rbenv/versions/2.5.6/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
        6: from /home/shinya/.rbenv/versions/2.5.6/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
        5: from /home/shinya/workspace/jets/lib/jets.rb:19:in `<top (required)>'
        4: from /home/shinya/.rbenv/versions/2.5.6/lib/ruby/gems/2.5.0/gems/activesupport-6.0.1/lib/active_support/dependencies.rb:325:in `require'
        3: from /home/shinya/.rbenv/versions/2.5.6/lib/ruby/gems/2.5.0/gems/activesupport-6.0.1/lib/active_support/dependencies.rb:291:in `load_dependency'
        2: from /home/shinya/.rbenv/versions/2.5.6/lib/ruby/gems/2.5.0/gems/activesupport-6.0.1/lib/active_support/dependencies.rb:325:in `block in require'
        1: from /home/shinya/.rbenv/versions/2.5.6/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:122:in `require'
/home/shinya/.rbenv/versions/2.5.6/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:122:in `require': cannot load such file -- cfn_status (LoadError)
```

It seems `cfn_status` is not properly loaded. This PR fixes the loading issue.

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
