### PR TITLE
Fix error with 'references' column in 'jets generate model'

### DIFF
--- a/lib/jets/commands/db/tasks/dummy/app.rb
+++ b/lib/jets/commands/db/tasks/dummy/app.rb
@@ -4,8 +4,12 @@ module Jets::Commands::Db::Tasks::Dummy
   class App
     def config
       Config.new(
+        active_record: {
+          belongs_to_required_by_default: true
+        },
         paths: {
           db: ["db"],
+          "db/migrate": ["db/migrate"]
         }
       )
     end

--- a/lib/jets/generator.rb
+++ b/lib/jets/generator.rb
@@ -78,6 +78,9 @@ class Jets::Generator
 
   def run(behavior=:invoke)
     self.class.require_generators
+
+    Jets::Commands::Db::Tasks.load!
+
     Rails::Generators.configure!(config)
     Rails::Generators.invoke(@generator, @args, behavior: behavior, destination_root: Jets.root)
   end


### PR DESCRIPTION
Really appreciate all the hard work that's gone into making this neat framework. Hoping the following contribution helps in some small way. If there's anything you'd like me to change, please let me know!

----

- I read the contributing document at https://rubyonjets.com/docs/contributing/

This is a 🐞 bug fix.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

When using the `jets generate model` command with a *references* field (for example, `jets generate model post user:references title:string`), I'm seeing the following error:

```
NoMethodError: undefined method `application' for Rails:Module
```

The issue seems to stem from the fact that [this commit](https://github.com/rails/rails/commit/8b4d344815655027d9f7584c0a59271dce8f1d5a#diff-06ee83dd4b3615868328dd430573327bR147) added a check that references `Rails.application` in the following line of code:
https://github.com/rails/rails/blob/master/railties/lib/rails/generators/generated_attribute.rb#L146

I've gone through jets internals and the code changes in jets to support Rails 6, such as the introduction of `Jets::Commands::Db::Tasks::Dummy::App`. I'm not sure if this is the correct way to fix this, but gave it a shot. :)

I had some issues running `bundle exec rspec` since I don't have DynamoDB installed locally.

Appreciate all the hints/advice to get this PR across the finish line.

## Context

I've opened the PR directly. If I need to raise an issue first, please let me know.

## Version Changes

Possibly a minor version change.