### PR TITLE
add note about database adapter to quick start, also link to more docs

### DIFF
--- a/docs/_docs/database/activerecord.md
+++ b/docs/_docs/database/activerecord.md
@@ -5,6 +5,16 @@ nav_order: 52
 
 Jets also supports ActiveRecord and currently the PostgreSQL and MySQL.  This is configured with your `Gemfile` and `config/database.yml`.
 
+### Database Adapter
+
+The default database adapter configured by [jets new](https://rubyonjets.com/reference/jets-new/) is MySQL.
+
+    jets new demo
+
+If you would like to use PostgreSQL instead, use:
+
+    jets new demo --database=postgresql
+
 ## Migrations
 
 Here's an example of creating migrations:

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -15,7 +15,11 @@ In a hurry? No problem!  Here's a quick start to get going.
     jets db:create db:migrate
     jets server
 
-The `jets server` command starts a server that mimics API Gateway so you can test locally.  Open [http://localhost:8888/posts](http://localhost:8888/posts) and check out the site. Note, the `DATABASE_URL` format looks like this: `mysql2://dbuser:dbpass@localhost/demo_dev?pool=5`
+The `jets server` command starts a server that mimics API Gateway so you can test locally.  Open [http://localhost:8888/posts](http://localhost:8888/posts) and check out the site. Note, the `DATABASE_URL` format looks like this: `mysql2://dbuser:dbpass@localhost/demo_dev?pool=5`. The default database adapter configured by [jets new](https://rubyonjets.com/reference/jets-new/) is MySQL.  If you would like to use PostgreSQL instead, use:
+
+    jets new demo --database=postgresql
+
+More info: [Database ActiveRecord Docs]({% link _docs/database/activerecord.md %})
 
 Create some posts records. The posts page should look something like this:
 


### PR DESCRIPTION
This is a 🧐 documentation change.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Update docs to note how to use a different database adapter.

## Context

#404 

