### PR TITLE
enable sse-s3 encryption on parent s3 bucket by default

### DIFF
--- a/lib/jets/cfn/builders/parent_builder.rb
+++ b/lib/jets/cfn/builders/parent_builder.rb
@@ -26,7 +26,13 @@ module Jets::Cfn::Builders
       add_description("Jets: #{Jets.version} Code: #{Util::Source.version}")
 
       # Initial s3 bucket, used to store code zipfile and templates Jets generates
-      resource = Jets::Resource::S3::Bucket.new(logical_id: "s3_bucket")
+      resource = Jets::Resource::S3::Bucket.new(logical_id: "s3_bucket",
+        bucket_encryption: {
+          server_side_encryption_configuration: [
+            server_side_encryption_by_default: {
+              sse_algorithm: "AES256"
+          }]}
+      )
       add_resource(resource)
       add_outputs(resource.outputs)
 


### PR DESCRIPTION
This is a 🙋‍♂️ feature or enhancement.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Enable SSE-S3 Encryption on the parent jets s3 bucket by default.

## Version Changes

Patch