### PR TITLE
Fix `render` doesn't recognize relative partial path with haml

### DIFF
--- a/lib/jets/overrides/rails/rendering_helper.rb
+++ b/lib/jets/overrides/rails/rendering_helper.rb
@@ -6,7 +6,7 @@ module Jets::RenderingHelper
   #   <%= render "articles/mypartial" %>
   def render(options = {}, locals = {}, &block)
     if options.is_a?(String) && !options.include?('/')
-      folder = _get_containing_folder(caller[0])
+      folder = _get_containing_folder(caller)
       partial_name = options # happens to be the partial name
       partial_name = "#{folder}/#{partial_name}"
       options = partial_name
@@ -17,7 +17,9 @@ module Jets::RenderingHelper
 
   # Ugly, going back up the caller stack to find out what view path
   # we are in
-  def _get_containing_folder(caller_line)
+  def _get_containing_folder(caller_lines)
+    caller_line = caller_lines.find { |caller_line| !caller_line.include?('gems') }
+
     text = caller_line.split(':').first
     # .../fixtures/apps/demo/app/views/posts/index.html.erb
     text.split('/')[-2] # posts


### PR DESCRIPTION
This is a 🐞 bug fix.

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Haml gem injects a middle layer between `render` and `Jets::RenderingHelper`. https://github.com/haml/haml/blob/master/lib/haml/helpers/action_view_mods.rb#L6. Because of this, `folder` cannot be extracted correctly from callers.

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
