### PR TITLE
Development hot-reloading for projects using ActiveRecord STI Issue

### DIFF
--- a/jets.gemspec
+++ b/jets.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "actionview", "~> 6.0.0"
   spec.add_dependency "activerecord", "~> 6.0.0"
   spec.add_dependency "activesupport", "~> 6.0.0"
-  spec.add_dependency "aws-mfa-secure"
+  spec.add_dependency "aws-mfa-secure", "~> 0.4.0"
   spec.add_dependency "aws-sdk-apigateway"
   spec.add_dependency "aws-sdk-cloudformation"
   spec.add_dependency "aws-sdk-cloudwatchlogs"

--- a/lib/jets/controller/middleware/reloader.rb
+++ b/lib/jets/controller/middleware/reloader.rb
@@ -7,7 +7,7 @@ module Jets::Controller::Middleware
     @@reload_lock = Mutex.new
     def call(env)
       @@reload_lock.synchronize do
-        Jets::Autoloaders.main.reload
+        Zeitwerk::Loader.eager_load_all
         @app.call(env)
       end
     end


### PR DESCRIPTION
This is a 🐞 bug fix.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fixes hot-reloading for projects using ActiveRecord Single Table Inheritance , STI , in development mode.  

Handled by reloading all dependent gems with `Zeitwerk::Loader.eager_load_all`

Also, ensure using https://github.com/tongueroo/aws-mfa-secure version ~> 0.4.0 which needed a fix for 
eager_load_all to work.

## Context

https://community.rubyonjets.com/t/subclassnotfound-single-table-inheritance-error-due-to-unexpected-class-reloading/338

## Version Changes

Patch