### PR TITLE
add config.hot_reload option to allow override

### DIFF
--- a/lib/jets/application/defaults.rb
+++ b/lib/jets/application/defaults.rb
@@ -155,6 +155,8 @@ class Jets::Application
       config.deploy.stagger.enabled = false
       config.deploy.stagger.batch_size = 10
 
+      config.hot_reload = Jets.env.development?
+
       config
     end
 

--- a/lib/jets/controller/middleware/reloader.rb
+++ b/lib/jets/controller/middleware/reloader.rb
@@ -7,7 +7,7 @@ module Jets::Controller::Middleware
     @@reload_lock = Mutex.new
     def call(env)
       @@reload_lock.synchronize do
-        Zeitwerk::Loader.eager_load_all
+        Jets::Autoloaders.main.reload
         @app.call(env)
       end
     end

--- a/lib/jets/middleware/default_stack.rb
+++ b/lib/jets/middleware/default_stack.rb
@@ -12,7 +12,7 @@ module Jets::Middleware
         middleware.use Rack::Runtime
         middleware.use Jets::Controller::Middleware::Cors if cors_enabled?
         middleware.use Rack::MethodOverride # must come before Middleware::Local for multipart post forms to work
-        middleware.use Jets::Controller::Middleware::Reloader if Jets.env.development?
+        middleware.use Jets::Controller::Middleware::Reloader if Jets.config.hot_reload
         middleware.use Jets::Controller::Middleware::Local # mimics AWS Lambda for local server only
         middleware.use session_store, session_options
         middleware.use Rack::Head


### PR DESCRIPTION
* defaults to true in development mode
* allow override in case want behavior to be different on AWS Lambda

This also reverts #412 which was not the proper fix

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Add `config.hot_reload` option to allow override of default behavior. 

Hot reloading causes issues with STI. Related #412

## How to Test

Make sure hot-reloading still works.

1. start server
2. change file
3. refresh url and see the changes without having to restart

## Version Changes

Patch