### PR TITLE
more narrow check for /gems/ for caller_lines search

### DIFF
--- a/lib/jets/overrides/rails/rendering_helper.rb
+++ b/lib/jets/overrides/rails/rendering_helper.rb
@@ -18,8 +18,7 @@ module Jets::RenderingHelper
   # Ugly, going back up the caller stack to find out what view path
   # we are in
   def _get_containing_folder(caller_lines)
-    caller_line = caller_lines.find { |caller_line| !caller_line.include?('gems') }
-
+    caller_line = caller_lines.find { |l| !l.include?('/gems/') }
     text = caller_line.split(':').first
     # .../fixtures/apps/demo/app/views/posts/index.html.erb
     text.split('/')[-2] # posts

--- a/spec/lib/jets/rails_overrides/rails_overrides_spec.rb
+++ b/spec/lib/jets/rails_overrides/rails_overrides_spec.rb
@@ -10,9 +10,11 @@ describe "Rails Overrides" do
   end
 
   it "get_controller_name" do
-    caller_line = "/Users/tung/src/tongueroo/jets/spec/fixtures/apps/demo/app/views/posts/index.html.erb:3:in `___sers_tung_src_tongueroo_jets_spec_fixtures_apps_demo_app_views_posts_index_html_erb__1209297671030770324_70251796312860'
-    "
-    folder = view._get_containing_folder(caller_line)
+    caller_lines = [
+      "/home/ec2-user/.rbenv/versions/2.5.6/lib/ruby/gems/2.5.0/gems/haml-5.1.2/lib/haml/helpers/action_view_mods.rb:13:in `render'",
+      "/Users/tung/src/tongueroo/jets/spec/fixtures/apps/demo/app/views/posts/index.html.erb:3:in `___sers_tung_src_tongueroo_jets_spec_fixtures_apps_demo_app_views_posts_index_html_erb__1209297671030770324_70251796312860'
+    "]
+    folder = view._get_containing_folder(caller_lines)
     expect(folder).to eq "posts"
   end
 end


### PR DESCRIPTION
* also fix specs and account for case
* related #410

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

More narrowly scope the search for caller_lines to find the template name in the overridden rails render method.

## Context

#410 

## How to Test

1. Add `gem 'haml-jets'` to Gemfile
2. In a view, render out to another partial that is haml
3. It should now find the partial properly and render successfully

## Version Changes

Patch