### PR TITLE
docs: aws cli install required, also note how to deploy to multiple regions

### DIFF
--- a/docs/_docs/deploy.md
+++ b/docs/_docs/deploy.md
@@ -50,4 +50,11 @@ To deploy to different environments:
 
     jets deploy production
 
+## Deploying to Multiple Regions
+
+Deploying to multiple regions can be achieved with `AWS_REGION`.  Example:
+
+    AWS_REGION=us-east-1 jets deploy
+    AWS_REGION=us-west-2 jets deploy
+
 {% include prev_next.md %}

--- a/docs/_docs/install.md
+++ b/docs/_docs/install.md
@@ -54,7 +54,7 @@ Here are the instructions to install MySQL and PostgreSQL:
 
 ### AWS CLI
 
-The AWS CLI is not required but is strongly recommended so that you can make use of AWS Profiles. You can install the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/installing.html) via pip.
+The AWS CLI required. You can install the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/installing.html) via pip.
 
     pip install awscli --upgrade --user
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -45,4 +45,6 @@ API Gateway:
 
 Congratulations!  You have successfully deployed your serverless ruby application. It's that simple. 😁
 
+Note: Make sure to also have the aws cli installed: [Install docs]({% link _docs/install.md %})
+
 {% include prev_next.md %}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 ENV["JETS_TEST"] = "1"
 ENV["JETS_ENV"] = "test"
 ENV["JETS_ROOT"] = "./spec/fixtures/apps/franky"
-# Ensures aws api never called. Fixture home folder does not contain ~/.aws/credentails
+# Ensures aws api never called. Fixture home folder does not contain ~/.aws/credentials
 ENV['HOME'] = File.join(Dir.pwd,'spec/fixtures/home')
 ENV['SECRET_KEY_BASE'] = 'fake'
 ENV['AWS_MFA_SECURE_TEST'] = '1'


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
<!-- This is a 🙋‍♂️ feature or enhancement. -->
This is a 🧐 documentation change.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Update docs to state that the aws cli is required to be installed. 

## Context

#403

## How to Test

N/A

## Version Changes

N/A