### PR TITLE
'jets call' honours region configuration

### DIFF
--- a/lib/jets/commands/call.rb
+++ b/lib/jets/commands/call.rb
@@ -134,7 +134,7 @@ class Jets::Commands::Call
     return unless system("type pbcopy > /dev/null")
 
     # TODO: for add_console_link_to_clipboard get the region from the ~/.aws/config and AWS_PROFILE setting
-    region = Aws.config[:region] || 'us-east-1'
+    region = Aws::S3::Client.new.config.region || ENV["AWS_REGION"] ||'us-east-1'
     link = "https://console.aws.amazon.com/lambda/home?region=#{region}#/functions/#{function_name}?tab=configuration"
     system("echo #{link} | pbcopy")
     puts "Pro tip: The Lambda Console Link to the #{function_name} function has been added to your clipboard." unless @options[:mute]


### PR DESCRIPTION

Maybe doing ```ENV["AWS_REGION"]``` as the second option is not really required, but I just wanted to fetch the information on all the possible ways before falling back to 'us-east-1'.

Also I searched through the project and Aws.config[:region] only occurs here. So no further action needed. 

This is a 🐞 bug fix.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Correct approach to get selected region implemented. Seen at https://github.com/aws/aws-sdk-ruby/issues/1042, ```Aws.config[:region]``` doesn't respond with correct values as long as it's not loaded by another client.

<!--
Provide a description of what your pull request changes.
-->

## Context
https://github.com/aws/aws-sdk-ruby/issues/1042

https://github.com/tongueroo/jets/issues/416

closes #416
## How to Test

Try using ```jets call``` with another region configured in ~/.aws/config without initialising any other part of the project.

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->
2.3.8 > 2.3.9
