### PR TITLE
Setting ENV["SCRIPT_NAME"] same as mount_at value.

### DIFF
--- a/lib/jets/internal/app/controllers/jets/mount_controller.rb
+++ b/lib/jets/internal/app/controllers/jets/mount_controller.rb
@@ -46,6 +46,7 @@ private
     path_info = env["PATH_INFO"]
     env["PATH_INFO"] = path_info.sub(mount_at,'')
     env["ORIGINAL_PATH_INFO"] = path_info
+    env["SCRIPT_NAME"] = mount_at
     env
   end
 


### PR DESCRIPTION
This is a 🐞 bug fix.

## Summary
Now setting env["SCRIPT_NAME"] = mount_at
This value is set when building a env variable for rack. 
This change prevent assets path from breaking when we mount gems in Jets Application.

## Context
 I faced this problem when I was accessing split gem's web interface. The CSS and JS files were not loading and throwing 404 error. Split is a Sinatra based AB testing platform. It uses url() method for defining the assets path. Which uses ENV["SCRIPT_NAME"] when constructing the assets path.  ENV["SCRIPT_NAME"] is set to empty string. 

So, suppose if I mount the gem at 'admin/split' the assets path should be 'http://localhost:3000/admin/split/style.css' but it is generating 'http://localhost:3000/style.css' and is breaking.

When I tested the same scenario within Rails application, everything is working fine. I couldn't find at what point is rails setting the SCRIPT_NAME in env variable but it is.

Faced the same issue, when accessing the Sidekiq gem' web interface.

Here is link of Sinatra uri/url helper method where is it using script_name for generating the path.
`https://www.rubydoc.info/gems/sinatra/Sinatra%2FHelpers:uri`

Please suggest if there is any better solution.
