### PR TITLE
use underscore for database name in database.yml

### DIFF
--- a/lib/jets/commands/new.rb
+++ b/lib/jets/commands/new.rb
@@ -24,6 +24,7 @@ module Jets::Commands
 
     def set_initial_variables
       @project_name = project_folder == '.' ? File.basename(Dir.pwd) : project_folder
+      @database_name = @project_name.gsub('-','_')
 
       # options is a frozen hash by Thor so cannot modify it.
       # Also had trouble unfreezing it with .dup. So using instance variables instead

--- a/lib/jets/commands/templates/skeleton/config/database.yml.tt
+++ b/lib/jets/commands/templates/skeleton/config/database.yml.tt
@@ -2,7 +2,7 @@ default: &default
   adapter: <%= @database == 'mysql' ? 'mysql2' : 'postgresql' %>
   encoding: <%= @database == 'mysql' ? 'utf8mb4' : 'unicode' %>
   pool: <%%= ENV["DB_POOL"] || 5  %>
-  database: <%%= ENV['DB_NAME'] || '<%= @project_name %>_development' %>
+  database: <%%= ENV['DB_NAME'] || '<%= @database_name %>_development' %>
 <% if @database == 'mysql' -%>
   username: <%%= ENV['DB_USER'] || 'root' %>
 <% else -%>
@@ -15,13 +15,13 @@ default: &default
 
 development:
   <<: *default
-  database: <%%= ENV['DB_NAME'] || '<%= @project_name %>_development' %>
+  database: <%%= ENV['DB_NAME'] || '<%= @database_name %>_development' %>
 
 test:
   <<: *default
-  database: <%= @project_name %>_test
+  database: <%= @database_name %>_test
 
 production:
   <<: *default
-  database: <%= @project_name %>_production
+  database: <%= @database_name %>_production
   url: <%%= ENV['DATABASE_URL'] %>


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Use underscore in the db name for the generated `config/database.yml` instead of dashes.  Example:

```yaml
database: my_api_development
```

VS

```yaml
database: my-api_development
```


