### PR TITLE
url_for: allow any activemodel compatiable object to work

### DIFF
--- a/lib/jets/overrides/rails/url_helper.rb
+++ b/lib/jets/overrides/rails/url_helper.rb
@@ -6,17 +6,16 @@ module Jets::UrlHelper
 
   # Basic implementation of url_for to allow use helpers without routes existence
   def url_for(options = nil) # :nodoc:
-    url = case options
-          when String
+    url = if options.is_a?(String)
             options
-          when :back
+          elsif options == :back
             _back_url
-          when ActiveRecord::Base
+          elsif options.respond_to?(:to_model)
             _handle_model(options)
-          when Array
+          elsif options.is_a?(Array)
             _handle_array(options)
           else
-            raise ArgumentError, "Please provided a String or ActiveRecord model to link_to as the the second argument. The Jets link_to helper takes as the second argument."
+            raise ArgumentError, "The Jets link_to helper only supports some types of arguments. Please provided a String or an object that supports ActiveModel to link_to as the the second argument."
           end
 
     add_stage_name(url)


### PR DESCRIPTION
- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Allow any `url_for` and hence view helpers to work for any model that is ActiveModel compatible.

## Context

Noticed url helpers would not when working with DynamoDB based models and standard the `form_with` tag. 

## How to Test

Use a ActiveModel and create a form.

