### PR TITLE
fix subtle bug when code doesnt get uploaded from newly generated shims

### DIFF
--- a/lib/jets/builders/code_builder.rb
+++ b/lib/jets/builders/code_builder.rb
@@ -98,8 +98,8 @@ module Jets::Builders
 
       # Code prep and zipping
       check_code_size!
-      calculate_md5s # must be called before generate_shims and create_zip_files
       generate_shims
+      calculate_md5s # must be called before create_zip_files because checksums need to be populated
       create_zip_files
     end
 

--- a/lib/jets/commands/deploy.rb
+++ b/lib/jets/commands/deploy.rb
@@ -152,6 +152,8 @@ module Jets::Commands
 
     # All CloudFormation states listed here: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-describing-stacks.html
     def exit_unless_updateable!
+      return if ENV['JETS_FORCE_UPDATEABLE'] # useful for debugging if stack stack updating
+
       stack_name = Jets::Naming.parent_stack_name
       exists = stack_exists?(stack_name)
       return unless exists # continue because stack could be updating


### PR DESCRIPTION
This is a 🐞 bug fix
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fix subtle bug when code doesn't get uploaded from newly generated shims. 

## How to Test

Tricky one to reproduce:

1. deploy 
2. make a change that will only affect the generated handler shims. IE: Add a custom domain
3. deploy again - notice that the code does not get re-uploaded as generated shims are not included in the md5 checksum calculation

After this change, code uploads just fine.

## Version Changes

Patch