### PR TITLE
add hosted zone id support

### DIFF
--- a/docs/_docs/routing/custom-domain.md
+++ b/docs/_docs/routing/custom-domain.md
@@ -64,6 +64,20 @@ If you need to switch this and avoid downtime, you will need to do a manual blue
 
 Jets does what is necessary to deploy route changes. Sometimes this requires replacing the Rest API entirely. Jets detects this and will create a brand new Rest API when needed. This is one of the reasons why a Custom Domain is recommended to be set up, so the endpoint url remains the same.  Generally, the route change detection works well. If you need to force the creation of a brand new Rest API, you can use `JETS_REPLACE_API=1 jets deploy`.
 
+## HostedZoneId
+
+You can also specify a `hosted_zone_id` instead of `hosted_zone_name`.
+
+```ruby
+Jets.application.configure do
+  config.domain.cert_arn = "arn:aws:acm:us-west-2:112233445577:certificate/8d8919ce-a710-4050-976b-b33da991e7e8" # String
+  config.domain.hosted_zone_name = "coolapp.com" # String
+  config.domain.hosted_zone_id = "/hostedzone/Z2E57RZEXAMPLE"
+end
+```
+
+Note, you should still specify the `hosted_zone_name` because it is conventionally used for the API Gateway Custom Domain name.
+
 ## Disable Route53
 
 If `config.domain.hosted_zone_name` is set, then `config.domain.route53=true` will be the default behavior. It is useful to turn off the Jets managed route53 record if you would like to manage the DNS yourself.  Though there may be little point as the DNS must always match the API Custom Domain Name.

--- a/lib/jets/resource/route53/record_set.rb
+++ b/lib/jets/resource/route53/record_set.rb
@@ -28,7 +28,12 @@ module Jets::Resource::Route53
         comment: "DNS record managed by Jets",
         name: name,
       }
-      base[:hosted_zone_name] = hosted_zone_name
+      hosted_zone_id = Jets.config.domain.hosted_zone_id
+      if hosted_zone_id
+        base[:hosted_zone_id] = hosted_zone_id
+      else
+        base[:hosted_zone_name] = hosted_zone_name
+      end
 
       if Jets.config.domain.apex
         base.merge(


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Adds ability to specific route53 host zone to use with `hosted_zone_id`. Docs: https://rubyonjets.com/docs/routing/custom-domain/ Example:

```ruby
Jets.application.configure do
  config.domain.cert_arn = "arn:aws:acm:us-west-2:112233445577:certificate/8d8919ce-a710-4050-976b-b33da991e7e8" # String
  config.domain.hosted_zone_name = "coolapp.com" # String
  config.domain.hosted_zone_id = "/hostedzone/Z2E57RZEXAMPLE"
end
```

## Context

Fixes #381

## How to Test

Add `hosted_zone_id` and deploy.

## Version Changes

Patch