### PR TITLE
use headers origin for actual host in case of cloudfront in front

### DIFF
--- a/lib/jets/controller/rendering.rb
+++ b/lib/jets/controller/rendering.rb
@@ -72,7 +72,8 @@ class Jets::Controller
     end
 
     def actual_host
-      headers["host"]
+      # actually host is in headers["origin"] when cloudfront is in front
+      headers["origin"] || headers["host"]
     end
 
   end


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

When CloudFront is in front of API Gateway, the actual host is in `headers["origin"]`. Favor `headers["origin"]` over `headers["host"]`, so things like `redirect_to` maintains the same domain.

## How to Test

Test app with CloudFront in front of API Gateway.

## Version Changes

Patch