### PR TITLE
Jets build no internet

### DIFF
--- a/lib/jets/builders/code_builder.rb
+++ b/lib/jets/builders/code_builder.rb
@@ -77,6 +77,7 @@ module Jets::Builders
     end
 
     def exist_on_s3?(filename)
+      return false if ENV['JETS_BUILD_NO_INTERNET']
       s3_key = "jets/code/#{filename}"
       begin
         s3.head_object(bucket: s3_bucket, key: s3_key)

--- a/lib/jets/job/dsl/dynamodb_event.rb
+++ b/lib/jets/job/dsl/dynamodb_event.rb
@@ -1,6 +1,8 @@
 module Jets::Job::Dsl
   module DynamodbEvent
     def dynamodb_event(table_name, options={})
+      return if ENV['JETS_BUILD_NO_INTERNET'] # Disable during build since jets build tries to init this
+
       stream_arn = full_dynamodb_stream_arn(table_name)
       default_iam_policy = default_dynamodb_stream_policy(stream_arn)
 


### PR DESCRIPTION
This is a 🐞 bug fix.

## Summary

When running `jets build` with JETS_BUILD_NO_INTERNET set, a couple things were still trying to hit AWS. This fixes those things.

## Context

Some people want to simply produce the zip, ex: if deploying to aws via other means, such as Terraform.

## How to Test

Run this on a machine without aws credentials setup:

```jets new api
cd api
JETS_BUILD_NO_INTERNET=true jets build```


## Version Changes

Minor version or less

