### PR TITLE
fix simple function tmp_loader

### DIFF
--- a/lib/jets/lambda/function_constructor.rb
+++ b/lib/jets/lambda/function_constructor.rb
@@ -35,7 +35,7 @@ module Jets::Lambda
     def build
       code = IO.read(@code_path)
       function_klass = Class.new(Jets::Lambda::Function)
-      function_klass.module_eval(code)
+      function_klass.module_eval(code, @code_path)
       adjust_tasks(function_klass)
       function_klass # assign this to a Constant for a pretty class name
     end

--- a/lib/jets/tmp_loader.rb
+++ b/lib/jets/tmp_loader.rb
@@ -8,7 +8,8 @@ module Jets
 
     def initialize(yaml_path=nil)
       yaml_path ||= "#{Jets.root}/handlers/data.yml"
-      @data = YAML.load_file(yaml_path) if File.exist?(yaml_path)
+      return unless File.exist?(yaml_path)
+      @data = YAML.load_file(yaml_path)
       @s3_bucket = @data['s3_bucket']
       @rack_zip = @data['rack_zip']
     end

--- a/spec/lib/jets/controller/response_spec.rb
+++ b/spec/lib/jets/controller/response_spec.rb
@@ -13,9 +13,9 @@ describe Jets::Controller::Response do
       resp.set_cookie(:favorite_food, "chocolate cookie")
       resp.set_cookie(:favorite_color, "yellow")
       resp.delete_cookie(:favorite_food)
-      expect(resp.headers).to eq({"Set-Cookie"=>
-        "favorite_color=yellow\n" +
-        "favorite_food=; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000"})
+      cookie = resp.headers["Set-Cookie"]
+      expect(cookie).to include("favorite_color=yellow")
+      expect(cookie).to include("max-age=0; expires=Thu, 01 Jan 1970 00:00:00")
     end
   end
 end


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fix simple functions being loading Jets outside of Jets.

```ruby
require 'bundler/setup'
require 'jets'
Jets.once

def lambda_handler(event:, context:)
  ...
end
```

## Context

https://community.rubyonjets.com/t/accessing-jets-models-in-simple-functions/288/7

## How to Test

Deploy simple functions.

## Version Changes

Patch