### PR TITLE
Remove out-of-date note about FIFO Queue

### DIFF
--- a/docs/_docs/events/sqs.md
+++ b/docs/_docs/events/sqs.md
@@ -160,8 +160,4 @@ Here's an example of the event payload.
 
 An IAM policy is generated for the Lambda function associated with the SQS event that allows the permissions needed.  You can control and override the IAM policy with normal [IAM Policies]({% link _docs/iam-policies.md %}) if needed though.
 
-## FIFO Queue
-
-Note, AWS does not currently support Lambda function triggers with FIFO queues, so the queue must be a standard queue to use Lambda triggers.  If you are using a FIFO queue, a [possible way](https://stackoverflow.com/questions/53416890/cant-trigger-lambdas-on-sqs-fifo) to process the messages is with a Job that polls the queues and does the processing.
-
 {% include prev_next.md %}


### PR DESCRIPTION
This is a 🧐 documentation change.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [X] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Remove out-of-date note about FIFO Queue

## Context

AWS Lambda now supports Amazon SQS FIFO as an event source.
https://aws.amazon.com/about-aws/whats-new/2019/11/aws-lambda-supports-amazon-sqs-fifo-event-source/

