### PR TITLE
Allow parameters filtering

### DIFF
--- a/docs/_docs/app-config/filtering_params.md
+++ b/docs/_docs/app-config/filtering_params.md
@@ -1,0 +1,23 @@
+---
+title: Filtering Params
+nav_order: 43
+---
+
+By default, all params and event payload will be logged to CloudWatch in every request. You can override this setting with `filtered_parameters` to
+filter out sensitive information and mask it as FILTERED within the request log.
+
+```ruby
+Jets.application.configure do
+  config.controllers.filtered_parameters += [:password, :credit_card]
+end
+```
+
+You can also use dot notation for nested parameters
+
+```ruby
+class PostsController < ApplicationController
+  config.controllers.filtered_parameters += ["user.password"]
+end
+```
+
+{% include prev_next.md %}

--- a/docs/_includes/subnav.html
+++ b/docs/_includes/subnav.html
@@ -50,6 +50,7 @@
     <li><a href="{% link _docs/app-config.md %}">App Configuration</a>
       <ul>
         <li><a href="{% link _docs/app-config/forgery-protection.md %}">Forgery Protection</a></li>
+        <li><a href="{% link _docs/app-config/filtering_params.md %}">Filtering Params</a></li>
       </ul>
     </li>
     <li><a href="{% link _docs/rack.md %}">Rack Compatible</a>

--- a/lib/jets/application/defaults.rb
+++ b/lib/jets/application/defaults.rb
@@ -149,6 +149,7 @@ class Jets::Application
 
       config.controllers = ActiveSupport::OrderedOptions.new
       config.controllers.default_protect_from_forgery = nil
+      config.controllers.filtered_parameters = []
 
       config.deploy = ActiveSupport::OrderedOptions.new
       config.deploy.stagger = ActiveSupport::OrderedOptions.new

--- a/lib/jets/controller/parameters_filter.rb
+++ b/lib/jets/controller/parameters_filter.rb
@@ -1,0 +1,29 @@
+require "active_support/parameter_filter"
+
+class Jets::Controller
+  class ParametersFilter
+    attr_reader :filters, :params_filter
+
+    def initialize(filters)
+      @filters = filters
+      @params_filter = ActiveSupport::ParameterFilter.new(filters)
+    end
+
+    def filter(params)
+      params_filter.filter(params)
+    end
+
+    def filter_json(json_text)
+      return json_text if filters.empty?
+
+      begin
+        hash_params = JSON.parse(json_text)
+        filtered_params = filter(hash_params)
+        JSON.dump(filtered_params)
+      rescue JSON::ParserError
+        String.new
+      end
+    end
+
+  end
+end

--- a/lib/jets/controller/parameters_filter.rb
+++ b/lib/jets/controller/parameters_filter.rb
@@ -10,7 +10,7 @@ class Jets::Controller
     end
 
     def filter(params)
-      params_filter.filter(params)
+      params && params_filter.filter(params)
     end
 
     def filter_json(json_text)

--- a/lib/jets/controller/parameters_filter.rb
+++ b/lib/jets/controller/parameters_filter.rb
@@ -14,7 +14,7 @@ class Jets::Controller
     end
 
     def filter_json(json_text)
-      return json_text if filters.empty?
+      return json_text if filters.blank? || json_text.blank?
 
       begin
         hash_params = JSON.parse(json_text)

--- a/lib/jets/controller/params.rb
+++ b/lib/jets/controller/params.rb
@@ -1,4 +1,5 @@
 require "action_controller/metal/strong_parameters"
+require "active_support/parameter_filter"
 require "action_dispatch"
 require "rack"
 
@@ -27,6 +28,10 @@ class Jets::Controller
         params = ActionDispatch::Request::Utils.normalize_encode_params(params) # for file uploads
         ActionController::Parameters.new(params)
       end
+    end
+
+    def filtered_parameters(**kwargs)
+      parameter_filter.filter params(**kwargs, raw: true) # Always filter raw hash
     end
 
     def query_parameters
@@ -82,6 +87,10 @@ class Jets::Controller
     def base64_decode(body)
       return nil if body.nil?
       Base64.decode64(body)
+    end
+
+    def parameter_filter
+      @parameter_filter ||= ActiveSupport::ParameterFilter.new Jets.config.controllers.filtered_parameters
     end
   end
 end

--- a/lib/jets/controller/params.rb
+++ b/lib/jets/controller/params.rb
@@ -1,5 +1,4 @@
 require "action_controller/metal/strong_parameters"
-require "active_support/parameter_filter"
 require "action_dispatch"
 require "rack"
 
@@ -90,7 +89,7 @@ class Jets::Controller
     end
 
     def parameter_filter
-      @parameter_filter ||= ActiveSupport::ParameterFilter.new Jets.config.controllers.filtered_parameters
+      @parameter_filter ||= ParametersFilter.new Jets.config.controllers.filtered_parameters
     end
   end
 end

--- a/spec/lib/jets/controller/base_spec.rb
+++ b/spec/lib/jets/controller/base_spec.rb
@@ -147,4 +147,36 @@ describe Jets::Controller::Base do
       expect(resp['headers']['x-jets-base64']).to eq "no"
     end
   end
+
+  describe "#log_info_start" do
+    let(:event) { json_file("spec/fixtures/dumps/api_gateway/request.json") }
+
+    context "When Jets.config is set with filtered_parameters" do
+      it "Logs event and params with sensitive data masked" do
+        Jets.config.controllers.filtered_parameters = [:a, :key1]  #a from queryStringParameters and key1 from body
+
+        expect(Jets.logger).to receive(:info).with('  Parameters: {"key3":"value3","key2":"value2","key1":"[FILTERED]","a":"[FILTERED]","b":"2"}')
+
+        expected_event_log = '  Event: {"resource":"/posts","path":"/posts","httpMethod":"POST","headers":{"Accept":"*/*","Accept-Encoding":"gzip, deflate","cache-control":"no-cache","CloudFront-Forwarded-Proto":"https","CloudFront-Is-Desktop-Viewer":"true","CloudFront-Is-Mobile-Viewer":"false","CloudFront-Is-SmartTV-Viewer":"false","CloudFront-Is-Tablet-Viewer":"false","CloudFront-Viewer-Country":"US","Content-Type":"text/plain","Host":"uhghn8z6t1.execute-api.us-east-1.amazonaws.com","Postman-Token":"7166b11b-59de-4e7b-ad35-24e556b7a083","User-Agent":"PostmanRuntime/6.4.1","Via":"1.1 55676da1e5c0a9c4e60a94a95b01dc04.cloudfront.net (CloudFront)","X-Amz-Cf-Id":"iERhUw6ghRnv1uRYfxJaUsDGWVbERFSZ4K00CIgZtJ0T6yeFdItMeQ==","X-Amzn-Trace-Id":"Root=1-59f50229-587ec5271678236e50ad91b1","X-Forwarded-For":"69.42.1.180, 54.239.203.100","X-Forwarded-Port":"443","X-Forwarded-Proto":"https"},"queryStringParameters":{"a":"[FILTERED]","b":"2"},"pathParameters":null,"stageVariables":null,"requestContext":{"path":"/stag/posts","accountId":"123456789012","resourceId":"c0yhg8","stage":"stag","requestId":"e5c39604-bc2d-11e7-abbe-1baaa0f8e02e","identity":{"cognitoIdentityPoolId":null,"accountId":null,"cognitoIdentityId":null,"caller":null,"apiKey":"","sourceIp":"69.42.1.180","accessKey":null,"cognitoAuthenticationType":null,"cognitoAuthenticationProvider":null,"userArn":null,"userAgent":"PostmanRuntime/6.4.1","user":null},"resourcePath":"/posts","httpMethod":"POST","apiId":"uhghn8z6t1"},"body":"{\"key3\":\"value3\",\"key2\":\"value2\",\"key1\":\"[FILTERED]\"}","isBase64Encoded":false}'
+        expect(Jets.logger).to receive(:info).with(expected_event_log)
+        expect(Jets.logger).to receive(:info).at_least(:once)
+
+        controller.log_info_start
+      end
+    end
+
+    context "When Jets.config is not set with filtered_parameters" do
+      it "Logs event and params with original payload" do
+        Jets.config.controllers.filtered_parameters = []
+
+        expect(Jets.logger).to receive(:info).with('  Parameters: {"key3":"value3","key2":"value2","key1":"value1","a":"1","b":"2"}')
+
+        expected_event_log = '  Event: {"resource":"/posts","path":"/posts","httpMethod":"POST","headers":{"Accept":"*/*","Accept-Encoding":"gzip, deflate","cache-control":"no-cache","CloudFront-Forwarded-Proto":"https","CloudFront-Is-Desktop-Viewer":"true","CloudFront-Is-Mobile-Viewer":"false","CloudFront-Is-SmartTV-Viewer":"false","CloudFront-Is-Tablet-Viewer":"false","CloudFront-Viewer-Country":"US","Content-Type":"text/plain","Host":"uhghn8z6t1.execute-api.us-east-1.amazonaws.com","Postman-Token":"7166b11b-59de-4e7b-ad35-24e556b7a083","User-Agent":"PostmanRuntime/6.4.1","Via":"1.1 55676da1e5c0a9c4e60a94a95b01dc04.cloudfront.net (CloudFront)","X-Amz-Cf-Id":"iERhUw6ghRnv1uRYfxJaUsDGWVbERFSZ4K00CIgZtJ0T6yeFdItMeQ==","X-Amzn-Trace-Id":"Root=1-59f50229-587ec5271678236e50ad91b1","X-Forwarded-For":"69.42.1.180, 54.239.203.100","X-Forwarded-Port":"443","X-Forwarded-Proto":"https"},"queryStringParameters":{"a":"1","b":"2"},"pathParameters":null,"stageVariables":null,"requestContext":{"path":"/stag/posts","accountId":"123456789012","resourceId":"c0yhg8","stage":"stag","requestId":"e5c39604-bc2d-11e7-abbe-1baaa0f8e02e","identity":{"cognitoIdentityPoolId":null,"accountId":null,"cognitoIdentityId":null,"caller":null,"apiKey":"","sourceIp":"69.42.1.180","accessKey":null,"cognitoAuthenticationType":null,"cognitoAuthenticationProvider":null,"userArn":null,"userAgent":"PostmanRuntime/6.4.1","user":null},"resourcePath":"/posts","httpMethod":"POST","apiId":"uhghn8z6t1"},"body":"{\n  \"key3\": \"value3\",\n  \"key2\": \"value2\",\n  \"key1\": \"value1\"\n}","isBase64Encoded":false}'
+        expect(Jets.logger).to receive(:info).with(expected_event_log)
+        expect(Jets.logger).to receive(:info).at_least(:once)
+
+        controller.log_info_start
+      end
+    end
+  end
 end

--- a/spec/lib/jets/controller/parameters_filter_spec.rb
+++ b/spec/lib/jets/controller/parameters_filter_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe Jets::Controller::ParametersFilter do
+  describe "#filter_json" do
+    let(:result) do
+      described_class.new(filtered_values).filter_json(json_text)
+    end
+
+    let(:json_text) do
+      JSON.dump(
+        password: "private_text",
+        password_confirmation: 'private_text_wrong',
+        name: 'Joe',
+        bio: 'Ruby on jets!'
+      )
+    end
+
+    context 'When filtered_parameters is not empty' do
+      let(:filtered_values) { %i[password password_confirmation] }
+
+      it 'Should return a new json with filtered_parameters masked as [FILTERED]' do
+        expect(result).to eq("{\"password\":\"[FILTERED]\",\"password_confirmation\":\"[FILTERED]\",\"name\":\"Joe\",\"bio\":\"Ruby on jets!\"}")
+      end
+    end
+
+    context 'When filtered_parameters is empty' do
+      let(:filtered_values) { [] }
+
+      it 'Should return the original json text' do
+        expect(result).to eq(json_text)
+      end
+    end
+
+    context 'When json_text has wrong format' do
+      let(:filtered_values) { %i[password password_confirmation] }
+      let(:json_text) { "just a text" }
+
+      it 'Should return a blank string' do
+        expect(result).to eq("")
+      end
+    end
+  end
+end

--- a/spec/lib/jets/controller/params_spec.rb
+++ b/spec/lib/jets/controller/params_spec.rb
@@ -83,6 +83,13 @@ describe Jets::Controller::Params do
   end
 
   describe "#filtered_params" do
+    let(:event) { {} }
+
+    it "Forwards options to params" do
+      expect(controller).to receive(:params).with(body_parameters: false, path_parameters: true, raw: true)
+
+      controller.send(:filtered_parameters, body_parameters: false, path_parameters: true, raw: false)
+    end
 
     context "With plain filtered parameters" do
       let(:event) { multipart_event(:simple_form) }

--- a/spec/lib/jets/controller/params_spec.rb
+++ b/spec/lib/jets/controller/params_spec.rb
@@ -81,4 +81,61 @@ describe Jets::Controller::Params do
       end
     end
   end
+
+  describe "#filtered_params" do
+
+    context "With plain filtered parameters" do
+      let(:event) { multipart_event(:simple_form) }
+
+      it "Masks provided keys as [FILTERED]" do
+        Jets.config.controllers.filtered_parameters = [:title]
+
+        filtered_params = controller.send(:filtered_parameters)
+        expect(filtered_params).to eq(
+          "name" => "Tung",
+          "title" => "[FILTERED]"
+        )
+      end
+    end
+
+    context "With nested filtered parameters" do
+      let(:event) { multipart_event(:nested) }
+
+      it "Masks provided keys as [FILTERED]" do
+        Jets.config.controllers.filtered_parameters = ["foo.submit-name"]
+
+        filtered_params = controller.send(:filtered_parameters)
+        expect(filtered_params["foo"]["submit-name"]).to eq("[FILTERED]")
+      end
+    end
+
+    context "With nested array filtered parameters" do
+      let(:event) do
+        {
+          "headers" => {
+            "content-type" => "application/x-www-form-urlencoded; charset=UTF-8"
+          },
+          "body" => "users[0][name]=John&users[0][location]=Boston&users[1][name]=Luke&users[1][location]=Chicago"
+        }
+      end
+
+      it "Masks provided keys as [FILTERED]" do
+        Jets.config.controllers.filtered_parameters = [/users\.\d+\.name/]
+
+        filtered_params = controller.send(:filtered_parameters)
+        expect(filtered_params).to eq(
+          "users" => {
+            "0" => {
+              "name" => "[FILTERED]",
+              "location" => "Boston"
+            },
+            "1" => {
+              "name" => "[FILTERED]",
+              "location" => "Chicago"
+            }
+          }
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION

This is a 🙋‍♂️ feature or enhancement

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

This pull request adds support for parameters filtering in order to filter sensitive information out of the logs. ActiveSupport::ParameterFilter was used for this task.


## Context

Related to this issue: https://github.com/tongueroo/jets/issues/399

## How to Test

I created this repo https://github.com/josediaz16/jets_demo following guides from https://github.com/tongueroo/jets/blob/master/readme/testing.md.

I had some troubles during testing: 

- I had to add `cfn_status` to Gemfile because an error like mentioned [here](https://github.com/tongueroo/jets/pull/400) occurs. 
- When running the local integration tests I got 4 failures because of `InvalidAuthenticityToken`, but the same happens using current version of Jets, I wouldn't think this PR affects that.


