### PR TITLE
Fix ApiResources with long names not in template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project *loosely tries* to adhere to [Semantic Versioning](http://semver.org/).
 
+## [UNRELEASED]
+- Fixed ApiResources with long names not included in the main CloudFormation template
+
 ## [2.3.12]
 - #421 use underscore for database name in database.yml
 - #422 url_for: allow any activemodel compatiable object to work

--- a/lib/jets/resource.rb
+++ b/lib/jets/resource.rb
@@ -26,14 +26,14 @@ class Jets::Resource
     Jets::Resource.truncate_id(id)
   end
 
-  def self.truncate_id(id)
+  def self.truncate_id(id, postfix = '')
     # Api Gateway resource name has a limit of 64 characters.
     # Yet it throws not found when ID is longer than 62 characters and I don't know why.
     # To keep it safe, let's stick to the 62 characters limit.
-    if id.size > 62
-      "#{id[0..55]}#{Digest::MD5.hexdigest(id)[0..5]}"
+    if id.size + postfix.size > 62
+      "#{id[0..(55 - postfix.size)]}#{Digest::MD5.hexdigest(id)[0..5]}#{postfix}"
     else
-      id
+      "#{id}#{postfix}"
     end
   end
 

--- a/lib/jets/resource/api_gateway/method.rb
+++ b/lib/jets/resource/api_gateway/method.rb
@@ -83,7 +83,7 @@ module Jets::Resource::ApiGateway
     def resource_id
       @route.path == '' ?
        "RootResourceId" :
-       Jets::Resource.truncate_id("#{resource_logical_id.camelize}ApiResource")
+       Jets::Resource.truncate_id(resource_logical_id.camelize, "ApiResource")
     end
 
     # Example: Posts

--- a/lib/jets/resource/api_gateway/resource.rb
+++ b/lib/jets/resource/api_gateway/resource.rb
@@ -28,7 +28,7 @@ module Jets::Resource::ApiGateway
       if @path == ''
         "RootResourceId"
       else
-        Jets::Resource.truncate_id "#{path_logical_id(@path)}ApiResource"
+        Jets::Resource.truncate_id path_logical_id(@path), "ApiResource"
       end
     end
 
@@ -41,7 +41,7 @@ module Jets::Resource::ApiGateway
       if @path.include?('/') # posts/:id or posts/:id/edit
         parent_path = @path.split('/')[0..-2].join('/')
         parent_logical_id = path_logical_id(parent_path)
-        Jets::Resource.truncate_id("#{parent_logical_id}ApiResource")
+        Jets::Resource.truncate_id(parent_logical_id, "ApiResource")
       else
         "RootResourceId"
       end

--- a/spec/lib/jets/resource/api_gateway/method_spec.rb
+++ b/spec/lib/jets/resource/api_gateway/method_spec.rb
@@ -39,7 +39,7 @@ describe Jets::Resource::ApiGateway::Method do
       properties = resource.properties
       # pp properties # uncomment to debug
       expect(properties["RestApiId"]).to eq "!Ref RestApi"
-      expect(properties["ResourceId"]).to eq "!Ref PostsPostIdCommentsCommentIdImagesImagesSourceUrlsSource9fe958"
+      expect(properties["ResourceId"]).to eq "!Ref PostsPostIdCommentsCommentIdImagesImagesSourcaa1e8bApiResource"
       expect(properties["HttpMethod"]).to eq "GET"
     end
   end


### PR DESCRIPTION
This is a 🐞 bug fix.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

When ApiResource has a long name, it is being truncated by the
generator to match ApiGateway requirements of having resource names
no longer than 64 (62) characters.

Jets::Resource::ChildStack#controller_params when generating
templates are identifying resource ids by postfix, like Resource,
Authorizer or RootResourceId. Truncating was removing that postfix,
making it impossible to be properly recognized by that mechanism and
in effect, a failed deployment.

This fix changes the truncating code to make it shorter and keep
the postfix.
