### PR TITLE
Ignore *.local files when JETS_ENV_REMOTE=1

### DIFF
--- a/lib/jets/dotenv.rb
+++ b/lib/jets/dotenv.rb
@@ -22,18 +22,18 @@ class Jets::Dotenv
   # dotenv files with the following precedence:
   #
   # - .env.development.jets_env_extra (highest)
-  # - .env.development.remote (2nd highest)
-  # - .env.development.local
+  # - .env.development.remote (2nd highest, only if JETS_ENV_REMOTE=1)
+  # - .env.development.local (unless JETS_ENV_REMOTE=1)
   # - .env.development
-  # - .env.local - This file is loaded for all environments _except_ `test`.
+  # - .env.local - This file is loaded for all environments _except_ `test` or unless JETS_ENV_REMOTE=1
   # - .env - The original (lowest)
   #
   def dotenv_files
     files = [
       root.join(".env"),
-      (root.join(".env.local") unless Jets.env.test?),
+      (root.join(".env.local") unless (Jets.env.test? || @remote)),
       root.join(".env.#{Jets.env}"),
-      root.join(".env.#{Jets.env}.local"),
+      (root.join(".env.#{Jets.env}.local") unless @remote),
     ]
     files << root.join(".env.#{Jets.env}.remote") if @remote
     if ENV["JETS_ENV_EXTRA"]

--- a/spec/fixtures/apps/franky/.env.test.local
+++ b/spec/fixtures/apps/franky/.env.test.local
@@ -1,0 +1,1 @@
+ONLY_LOCAL=1

--- a/spec/fixtures/apps/franky/.env.test.remote
+++ b/spec/fixtures/apps/franky/.env.test.remote
@@ -1,0 +1,1 @@
+ONLY_REMOTE=1

--- a/spec/lib/jets/dotenv_spec.rb
+++ b/spec/lib/jets/dotenv_spec.rb
@@ -1,5 +1,15 @@
 describe Jets::Dotenv do
   describe "#load!" do
+    it "ignores *.remote files unless JETS_ENV_REMOTE=1" do
+      env = Jets::Dotenv.new(false).load!
+      expect(env["ONLY_REMOTE"]).to eq nil
+      expect(env["ONLY_LOCAL"]).to eq "1"
+    end
+    it "ignores *.local files when JETS_ENV_REMOTE=1" do
+      env = Jets::Dotenv.new(true).load!
+      expect(env["ONLY_REMOTE"]).to eq "1"
+      expect(env["ONLY_LOCAL"]).to eq nil
+    end
     it "replaces ssm:<relative-path> with SSM parameters prefixed with /<app-name>/<jets-env>/" do
       relative_path = "authenticated-url"
       value = "https://foo:bar@example.com"


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

*.local files where loaded when JETS_ENV_REMOTE=1 was set, which isn't the behavior one would expect.

Now *.local and *.remote files are mutually exclusive.

## Context

See discussion here:
https://community.rubyonjets.com/t/why-is-local-environment-loaded-when-jets-env-remote-1/378

## How to Test

Two new .env files were added to spec/fixtures/apps/franky.  Simply run "bundle exec rspec" and spec/lib/jets/dotenv_spec.rb will ensure that only *.local or only *.remote files are loaded by Dotenv.

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

