### PR TITLE
Forcing sort of initializers

### DIFF
--- a/docs/_docs/initializers.md
+++ b/docs/_docs/initializers.md
@@ -3,7 +3,7 @@ title: Initializers
 nav_order: 63
 ---
 
-Jets supports custom initialization by running your app's `config/initializers` files during the bootup process.
+Jets supports custom initialization by running your app's `config/initializers` files (in alphabetical order) during the bootup process.
 
 ## Common Initializers
 

--- a/lib/jets/booter.rb
+++ b/lib/jets/booter.rb
@@ -120,7 +120,7 @@ class Jets::Booter
 
     # All Turbines
     def app_initializers
-      Dir.glob("#{Jets.root}/config/initializers/**/*").each do |path|
+      Dir.glob("#{Jets.root}/config/initializers/**/*").sort.each do |path|
         load path
       end
     end

--- a/spec/fixtures/apps/franky/config/initializers/01_initializer.rb
+++ b/spec/fixtures/apps/franky/config/initializers/01_initializer.rb
@@ -1,0 +1,1 @@
+JETS_TEST_INITIALIZER_ONE_TIME = DateTime.current

--- a/spec/fixtures/apps/franky/config/initializers/02_initializer.rb
+++ b/spec/fixtures/apps/franky/config/initializers/02_initializer.rb
@@ -1,0 +1,1 @@
+JETS_TEST_INITIALIZER_TWO_TIME = DateTime.current

--- a/spec/lib/jets/application_spec.rb
+++ b/spec/lib/jets/application_spec.rb
@@ -64,4 +64,10 @@ describe Jets::Application do
       expect(spec_names).to eq ["primary", "primary_replica", "animals", "animals_replica"]
     end
   end
+
+  context "custom initializers" do
+    it "should load in order" do
+      expect(JETS_TEST_INITIALIZER_ONE_TIME).to be < JETS_TEST_INITIALIZER_TWO_TIME
+    end
+  end
 end


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->
Hello, I've added a call to `#sort` when globbing the initializers. The resulting paths from the `#glob` call are returned in the order given back by the OS, which isn't necessarily alphabetical.

## Context

This was just something silly I was burned by. I found this recent discussion while researching the issue: https://bugs.ruby-lang.org/issues/8709
<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## How to Test

<!--
Please provide instructions on how to test the fix. This speeds up reviewing the PR. If testing requires a demo Jets project, please provide an example repo.
-->
I've added initializers to the test app, and timestamp when they're invoked. If there is a better way to test, please let me know and I'll adjust.

## Version Changes

This could be patch-level change.
<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

