### PR TITLE
temp fix for actionmailer turbine initializer

### DIFF
--- a/lib/jets/internal/turbines/jets/mailer.rb
+++ b/lib/jets/internal/turbines/jets/mailer.rb
@@ -8,6 +8,7 @@ module Jets
     end
 
     initializer "action_mailer.set_configs" do |app|
+      app.config.action_mailer ||= ActiveSupport::OrderedOptions.new # TODO: temp fix. only happens sometimes?
       options = app.config.action_mailer
       options.default_url_options ||= {}
       options.default_url_options[:protocol] ||= "https"


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Sometimes the Lambda environment fails to load the actionmailer turbine initializer. Unsure exactly why. This is a temp fix to, at least, prevent the initializer from crashing. Will have to investigate why this is happening more thoroughly.

## Context

https://community.rubyonjets.com/t/undefined-method-default-url-options-for-nil-nilclass/400

## How to Test

Just regular deploy and test.

## Version Changes

Patch