### PR TITLE
Order routes so that nested resources always work

### DIFF
--- a/lib/jets/router.rb
+++ b/lib/jets/router.rb
@@ -93,18 +93,18 @@ module Jets
     # Useful for RouterMatcher
     #
     # Precedence:
-    # 1. Routes with no captures get highest precedence: posts/new
-    # 2. Then consider the routes with captures: post/:id
-    # 3. Last consider the routes with wildcards: *catchall
+    # Routes with wildcards are considered after routes without wildcards
     #
-    # Within these 2 groups we consider the routes with the longest path first
-    # since posts/:id and posts/:id/edit can both match.
+    # Routes with fewer captures are ordered first since both
+    # /posts/:post_id/comments/new and /posts/:post_id/comments/:id are equally
+    # long
+    #
+    # Routes with the same amount of captures and wildcards are orderd so that
+    # the longest path is considered first since posts/:id and posts/:id/edit
+    # can both match.
     def ordered_routes
-      length = Proc.new { |r| r.path.length * -1 }
-      capture_routes = routes.select { |r| r.path.include?(':') }.sort_by(&length)
-      wildcard_routes = routes.select { |r| r.path.include?('*') }.sort_by(&length)
-      simple_routes = (routes - capture_routes - wildcard_routes).sort_by(&length)
-      simple_routes + capture_routes + wildcard_routes
+      length = Proc.new { |r| [r.path.count("*"), r.path.count(":"), r.path.length * -1] }
+      routes.sort_by(&length)
     end
 
     class << self

--- a/spec/lib/jets/router_spec.rb
+++ b/spec/lib/jets/router_spec.rb
@@ -1394,6 +1394,17 @@ EOL
         expect(paths).to eq(
           ["posts/new", "posts", "posts/:id/edit", "posts/:id", "*catchall"])
       end
+
+      it "ordered_routes should sort nested resources new before show" do
+        router.draw do
+          resources :posts do
+            resources :comments
+          end
+          any "*catchall", to: "catch#all"
+        end
+        paths = router.ordered_routes.map(&:path).uniq
+        expect(paths.index("posts/:post_id/comments/new")).to be < paths.index("posts/:post_id/comments/:id")
+      end
     end
 
     context "direct as" do


### PR DESCRIPTION
/posts/:id/comments/new and /posts/:id/comments/:id both contain a `:`
and both have the same length, so it is nondeterministic which one will
match with the current implementation of ordered_routes.

<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->
At the moment for nested resources defined like this
```
nested_resources :posts do
  nested_resources :comments
end
```
the router can (and for me at least will) send `/posts/1/comments/new` to `CommentsController#show` instead of `CommentsController#new`, because routes for both capture a variable and the paths are equally long.

This PR changes it so that capturing more variables means that the route is considered less specific and will be checked after more specific routes have been tried.

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## How to Test

<!--
Please provide instructions on how to test the fix. This speeds up reviewing the PR. If testing requires a demo Jets project, please provide an example repo.
-->
Running the test added by this PR on the master branch demonstrates the issue (at least it does when I tried).


## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

