### PR TITLE
Fix Jets turbo DB encoding

### DIFF
--- a/lib/jets/turbo/templates/config/database.yml
+++ b/lib/jets/turbo/templates/config/database.yml
@@ -1,6 +1,10 @@
 default: &default
   adapter:  <%= @adapter %>
+<% if @adapter == 'postgresql' -%>
+  encoding: unicode
+<% else -%>
   encoding: utf8mb4
+<% end -%>
   pool: <%%= ENV["DB_POOL"] || 5  %>
   database: <%%= ENV['DB_NAME'] || '<%= @database_development %>' %>
 <% if @adapter == 'postgresql' -%>


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fixes `encoding` in `jets/turbo/templates/config/database.yml` by setting it according to the DB adapter in the current database config. `unicode` for postgresql otherwise `utf8mb4` (mysql)

## Context

Fixes https://github.com/tongueroo/jets/issues/441

## How to Test

<!--
Please provide instructions on how to test the fix. This speeds up reviewing the PR. If testing requires a demo Jets project, please provide an example repo.
-->


## Version Changes

Bump patch version.

