### PR TITLE
Print Cfn templates location after build

### DIFF
--- a/lib/jets/commands/build.rb
+++ b/lib/jets/commands/build.rb
@@ -32,6 +32,7 @@ module Jets::Commands
       clean_templates
       build_minimal_template
       build_all_templates if full?
+      puts "Generated CloudFormation templates at #{Jets.build_root}/templates"
     end
 
     def full?


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Prints out the location of CloudFormation templates after `jets build`

## Context

Closes https://github.com/tongueroo/jets/issues/442

## How to Test

Trivial change.

## Version Changes

Patch because I think it's a tiny enhancement.

