### PR TITLE
Handle forbidden error from s3

### DIFF
--- a/lib/jets/builders/code_builder.rb
+++ b/lib/jets/builders/code_builder.rb
@@ -82,7 +82,7 @@ module Jets::Builders
       begin
         s3.head_object(bucket: s3_bucket, key: s3_key)
         true
-      rescue Aws::S3::Errors::NotFound
+      rescue Aws::S3::Errors::NotFound, Aws::S3::Errors::Forbidden
         false
       end
     end


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

Recently `jets build` command is failed with `Aws::S3::Errors::Forbidden`.
Maybe someone created `bucket-does-not-yet-exist` as bucket name.
So `exist_on_s3?` method in `code_builder.rb` throw `Aws::S3::Errors::Forbidden` error.

Below is the log when I failed to build

```
Bundle install success.
Tidying project: removing ignored files to reduce package size.
=> rsync -a --links /tmp/jets/yahb-jets/stage/code/vendor/gems/ruby/2.5.0/ /tmp/jets/yahb-jets/stage/opt/ruby/gems/2.5.0/
=> Replacing compiled gems with AWS Lambda Linux compiled versions: /tmp/jets/yahb-jets/stage/opt
Checking projects gems for binary Lambda gems...
=> Generating shims in the handlers folder.
bundler: failed to load command: jets (/Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/bin/jets)
Aws::S3::Errors::Forbidden: 
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/gems/aws-sdk-core-3.92.0/lib/seahorse/client/plugins/raise_response_errors.rb:15:in `call'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/gems/aws-sdk-s3-1.61.2/lib/aws-sdk-s3/plugins/sse_cpk.rb:22:in `call'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/gems/aws-sdk-s3-1.61.2/lib/aws-sdk-s3/plugins/dualstack.rb:26:in `call'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/gems/aws-sdk-s3-1.61.2/lib/aws-sdk-s3/plugins/accelerate.rb:35:in `call'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/gems/aws-sdk-core-3.92.0/lib/aws-sdk-core/plugins/jsonvalue_converter.rb:20:in `call'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/gems/aws-sdk-core-3.92.0/lib/aws-sdk-core/plugins/idempotency_token.rb:17:in `call'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/gems/aws-sdk-core-3.92.0/lib/aws-sdk-core/plugins/param_converter.rb:24:in `call'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/gems/aws-sdk-core-3.92.0/lib/aws-sdk-core/plugins/response_paging.rb:10:in `call'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/gems/aws-sdk-core-3.92.0/lib/seahorse/client/plugins/response_target.rb:23:in `call'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/gems/aws-sdk-core-3.92.0/lib/seahorse/client/request.rb:70:in `send_request'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/gems/aws-sdk-s3-1.61.2/lib/aws-sdk-s3/client.rb:5602:in `head_object'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/bundler/gems/jets-73051956aa62/lib/jets/builders/code_builder.rb:83:in `exist_on_s3?'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/bundler/gems/jets-73051956aa62/lib/jets/builders/code_builder.rb:70:in `block in create_zip_files'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/bundler/gems/jets-73051956aa62/lib/jets/builders/code_builder.rb:68:in `each'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/bundler/gems/jets-73051956aa62/lib/jets/builders/code_builder.rb:68:in `create_zip_files'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/bundler/gems/jets-73051956aa62/lib/jets/builders/code_builder.rb:113:in `code_finish'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/bundler/gems/jets-73051956aa62/lib/jets/builders/code_builder.rb:42:in `block in build'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/bundler/gems/jets-73051956aa62/lib/jets/builders/code_builder.rb:38:in `chdir'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/bundler/gems/jets-73051956aa62/lib/jets/builders/code_builder.rb:38:in `build'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/bundler/gems/jets-73051956aa62/lib/jets/commands/build.rb:27:in `build_code'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/bundler/gems/jets-73051956aa62/lib/jets/commands/build.rb:22:in `build'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/bundler/gems/jets-73051956aa62/lib/jets/commands/build.rb:18:in `run'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/bundler/gems/jets-73051956aa62/lib/jets/commands/main.rb:12:in `build'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/gems/thor-1.0.1/lib/thor/command.rb:27:in `run'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/gems/thor-1.0.1/lib/thor/invocation.rb:127:in `invoke_command'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/gems/thor-1.0.1/lib/thor.rb:392:in `dispatch'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/bundler/gems/jets-73051956aa62/lib/jets/commands/base.rb:38:in `dispatch'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/bundler/gems/jets-73051956aa62/lib/jets/commands/base.rb:27:in `perform'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/bundler/gems/jets-73051956aa62/lib/jets/cli.rb:28:in `start'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/bundler/gems/jets-73051956aa62/lib/jets/cli.rb:5:in `start'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/bundler/gems/jets-73051956aa62/exe/jets:14:in `<top (required)>'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/bin/jets:23:in `load'
  /Users/kuchitama/.anyenv/envs/rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/bin/jets:23:in `<top (required)>'
```

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## How to Test

<!--
Please provide instructions on how to test the fix. This speeds up reviewing the PR. If testing requires a demo Jets project, please provide an example repo.
-->

Delete your s3 bucket of jets deployment and run `jets build`.


## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

