### PR TITLE
Feature/authorization scopes

### DIFF
--- a/docs/_docs/routing/authorizers/authorization-scopes.md
+++ b/docs/_docs/routing/authorizers/authorization-scopes.md
@@ -1,0 +1,27 @@
+---
+title: Authorization Scopes
+---
+
+You can configure the OAuth2 scope in the Gateway API Method Request in two ways:
+
+### Controller Wide
+
+You can configure controller-wide the OAuth2 Scope.  Example:
+
+```ruby
+class PostsController < ApplicationController
+    authorization_scopes %w[create delete]
+end
+```
+
+All PostsController actions will be using `create` and `delete` authorization scopes.
+
+### Route Specific
+
+You can also configure the OAuth2 Scope on a per-route basis with the `authorization_scopes ` option:
+
+```ruby
+Jets.application.routes.draw do
+  get  "posts", to: "posts#index", authorization_scopes: %w[create delete]
+end
+```

--- a/docs/_includes/subnav.html
+++ b/docs/_includes/subnav.html
@@ -40,6 +40,7 @@
             <li><a href="{% link _docs/routing/authorizers/authorizer-caching.md %}">Authorizer Caching</a></li>
             <li><a href="{% link _docs/routing/authorizers/authorizer-cognito.md %}">Authorizer Cognito</a></li>
             <li><a href="{% link _docs/routing/authorizers/authorization-types.md %}">Authorization Types</a></li>
+            <li><a href="{% link _docs/routing/authorizers/authorization-scopes.md %}">Authorization Scopes</a></li>
           </ul>
         </li>
         <li><a href="{% link _docs/routing/mount.md %}">Mount Rack Apps</a></li>

--- a/lib/jets/controller/authorization.rb
+++ b/lib/jets/controller/authorization.rb
@@ -6,7 +6,8 @@ class Jets::Controller
       class_attribute :auth_type,
                       :auth_to,
                       :auth_options, # for only and except filters
-                      :api_key_needed
+                      :api_key_needed,
+                      :authorization_scopes_value
     end
 
     class_methods do
@@ -28,6 +29,14 @@ class Jets::Controller
           self.auth_options = options # IE: only: %w[index] or expect: [:show]
         else
           self.auth_to
+        end
+      end
+
+      def authorization_scopes(value=nil)
+        if !value.nil?
+          self.authorization_scopes_value = value
+        else
+          self.authorization_scopes_value
         end
       end
 

--- a/lib/jets/resource/api_gateway/method.rb
+++ b/lib/jets/resource/api_gateway/method.rb
@@ -36,6 +36,8 @@ module Jets::Resource::ApiGateway
         method_responses: []
       }
       props[:authorizer_id] = authorizer_id if authorizer_id
+      props[:authorization_scopes] = authorization_scopes if authorization_scopes
+
       props
     end
 

--- a/lib/jets/resource/api_gateway/method/authorization.rb
+++ b/lib/jets/resource/api_gateway/method/authorization.rb
@@ -28,5 +28,14 @@ class Jets::Resource::ApiGateway::Method
         controller_klass.api_key_required ||
         Jets.config.api.api_key_required
     end
+
+    def authorization_scopes
+      if @route.authorization_scopes
+        authorization_scopes = @route.authorization_scopes
+      elsif controller_klass.authorization_scopes
+        authorization_scopes = controller_klass.authorization_scopes
+      end
+      authorization_scopes
+    end
   end
 end

--- a/lib/jets/router/route/authorizer.rb
+++ b/lib/jets/router/route/authorizer.rb
@@ -16,6 +16,10 @@ class Jets::Router::Route
       @options[:authorizer]
     end
 
+    def authorization_scopes
+      @options[:authorization_scopes]
+    end
+
     def authorization_type
       @options[:authorization_type] || inferred_authorization_type
     end

--- a/spec/fixtures/apps/franky/app/controllers/toys_controller.rb
+++ b/spec/fixtures/apps/franky/app/controllers/toys_controller.rb
@@ -1,5 +1,6 @@
 class ToysController < ApplicationController
   before_action :set_toy, only: [:show, :edit, :update, :delete]
+  authorization_scopes %w[create delete]
 
   # GET /toys
   def index

--- a/spec/lib/jets/resource/api_gateway/method_spec.rb
+++ b/spec/lib/jets/resource/api_gateway/method_spec.rb
@@ -62,4 +62,22 @@ describe Jets::Resource::ApiGateway::Method do
       expect(resource.properties["ApiKeyRequired"]).to eq 'true'
     end
   end
+
+  context "authorization scopes on rotes" do
+    let(:route) do
+      Jets::Router::Route.new(path: "posts", method: :get, to: "posts#index", authorization_scopes: %w[create delete])
+    end
+    it "can specify an authorization scopes" do
+      expect(resource.properties["AuthorizationScopes"]).to eq ["create", "delete"]
+    end
+  end
+
+  context "authorization scopes on controller" do
+    let(:route) do
+      Jets::Router::Route.new(path: "toys", method: :get, to: "toys#index")
+    end
+    it "can specify an authorization scopes" do
+      expect(resource.properties["AuthorizationScopes"]).to eq ["create", "delete"]
+    end
+  end
 end


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

I configured the authorizer in my project and I need to add the scope of OAuth. In your last answer, you wrote that it is not possible. I cloned the project and added the behavior.

I added two ways the add scope of OAuth, one on controllers and other on routes.

app/controller/toys_controller.rb

```ruby
class ToysController < ApplicationController
  authorization_scopes %w[create delete]
  # ...
end
```

config/routes.rb

```ruby
path: "posts", method: :get, to: "posts#index", authorization_scopes: %w[create delete]
```

**P.S.:** In the master branch, there are six text breaks. I added two new tests, in [spec/lib/jets/resource/api_gateway/method_spec.rb](spec/lib/jets/resource/api_gateway/method_spec.rb), they are fine.
    
## Context

https://community.rubyonjets.com/t/how-can-i-configure-the-oauth-scope-in-the-method-request/452

## How to Test

https://github.com/tongueroo/jets/commit/2a40e460b3c6d7c1f8f229e793bc587d8b65957c	

## Version Changes
	
2.6.0

