### PR TITLE
remove json gem dependency to loosen Gemfile.lock

### DIFF
--- a/docs/_docs/install.md
+++ b/docs/_docs/install.md
@@ -30,7 +30,7 @@ Once node is installed, install yarn with:
 
     npm install -g yarn
 
-You can use any version of yarn that works with webpacker. If you run into webpacker issues, try upgrading node and yarn to the latest version.
+You can use any version of yarn that works with webpacker. If you run into webpacker issues, try upgrading node and yarn to the latest version. Also, upgrading the `yarn.lock` file with `yarn upgrade` sometimes helps.
 
 ## Database
 

--- a/jets.gemspec
+++ b/jets.gemspec
@@ -50,7 +50,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "hashie"
   spec.add_dependency "jets-gems"
   spec.add_dependency "jets-html-sanitizer"
-  spec.add_dependency "json"
   spec.add_dependency "kramdown"
   spec.add_dependency "memoist"
   spec.add_dependency "mimemagic"


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Looks like on 4/16/2020 AWS Lambda rolled out an update that upgrades json to a specific version, as a part of a security upgrade. This breaks Lambda functions that have different json in their `Gemfile.lock` from the AWS Lambda runtime. By removing the json gem from the jets dependencies, it loosens up the version of json being used. This helps to mitigate future updates from AWS Lambda.

Note, this will not prevent jets project `Gemfile` or other gems in there that specify json from locking to a specific version of json. However, at least, jets won't be the gem that causes json to be bundled into Gemfile.lock. So there's some mitigation here.

## Context

https://community.rubyonjets.com/t/init-error-when-loading-handler-errortype-init-gem-loaderror/463/8

## How to Test

Deploy application, and it should still work.

## Version Changes

Patch