### PR TITLE
use Bundler.with_unbundled_env

### DIFF
--- a/lib/jets.rb
+++ b/lib/jets.rb
@@ -18,6 +18,8 @@ $:.unshift("#{gem_root}/lib")
 $:.unshift("#{gem_root}/vendor/cfn-status/lib")
 require "cfn_status"
 
+require "jets/core_ext/bundler"
+
 require "jets/autoloaders"
 Jets::Autoloaders.log! if ENV["JETS_AUTOLOAD_LOG"]
 Jets::Autoloaders.once.setup

--- a/lib/jets/builders/code_builder.rb
+++ b/lib/jets/builders/code_builder.rb
@@ -235,7 +235,7 @@ module Jets::Builders
 
       # Need to capture JETS_ROOT since can be changed by Turbo mode
       jets_root = Jets.root
-      Bundler.with_clean_env do
+      Bundler.with_unbundled_env do
         # Switch gemfile for Afterburner mode
         gemfile = ENV['BUNDLE_GEMFILE']
         ENV['BUNDLE_GEMFILE'] = "#{jets_root}/rack/Gemfile"

--- a/lib/jets/builders/ruby_packager.rb
+++ b/lib/jets/builders/ruby_packager.rb
@@ -59,7 +59,7 @@ module Jets::Builders
 
       FileUtils.rm_rf("#{cache_area}/.bundle")
       require "bundler" # dynamically require bundler so user can use any bundler
-      Bundler.with_clean_env do
+      Bundler.with_unbundled_env do
         sh(
           "cd #{cache_area} && " \
           "env bundle install --path #{cache_area}/vendor/gems --without development test"

--- a/lib/jets/commands/import/base.rb
+++ b/lib/jets/commands/import/base.rb
@@ -41,7 +41,7 @@ class Jets::Commands::Import
     end
 
     def bundle_install
-      Bundler.with_clean_env do
+      Bundler.with_unbundled_env do
         run "cd rack && bundle install"
       end
     end

--- a/lib/jets/commands/main.rb
+++ b/lib/jets/commands/main.rb
@@ -43,7 +43,7 @@ module Jets::Commands
       puts Jets::Booter.message
       Jets::Booter.check_config_ru!
       Jets::RackServer.start(options) unless ENV['JETS_RACK'] == '0' # rack server runs in background by default
-      Bundler.with_clean_env do
+      Bundler.with_unbundled_env do
         system(command)
       end
     end

--- a/lib/jets/commands/new.rb
+++ b/lib/jets/commands/new.rb
@@ -61,7 +61,7 @@ module Jets::Commands
     end
 
     def bundle_install
-      Bundler.with_clean_env do
+      Bundler.with_unbundled_env do
         system("BUNDLE_IGNORE_CONFIG=1 bundle install")
       end
     end

--- a/lib/jets/core_ext/bundler.rb
+++ b/lib/jets/core_ext/bundler.rb
@@ -1,0 +1,7 @@
+# Bundler 2.0 does yet not have with_unbundled_env
+# Bundler 2.1 deprecates with_unbundled_env for with_unbundled_env
+
+require "bundler"
+def Bundler.with_unbundled_env(&block)
+  with_clean_env(&block)
+end unless Bundler.respond_to?(:with_unbundled_env)

--- a/lib/jets/rack_server.rb
+++ b/lib/jets/rack_server.rb
@@ -34,7 +34,7 @@ module Jets
     def serve
       # Note, looks like stopping jets server with Ctrl-C sends the TERM signal
       # down to the sub bin/rackup command cleans up the child process fine.
-      Bundler.with_clean_env do
+      Bundler.with_unbundled_env do
         args = ''
         # only forward the host option, port is always 9292 for simplicity
         if @options[:host]

--- a/lib/jets/turbo/rails.rb
+++ b/lib/jets/turbo/rails.rb
@@ -110,7 +110,7 @@ class Jets::Turbo
     # TODO: remove duplication, copied from jets/commands/import/base.rb
     # And modified it slightly
     def bundle_install
-      Bundler.with_clean_env do
+      Bundler.with_unbundled_env do
         sh "cd #{build_area}/#{@project_folder}/rack && bundle install"
       end
     end


### PR DESCRIPTION
* removes bundler deprecation warning

<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Removes bundler deprecation warning. Keep old versions of bundler working for now.

## Context

Fixes #449 

## How to Test

Deploy and make sure app is still working on Lambda.

## Version Changes

Patch