### PR TITLE
Update lamdba permissions for minimal-iam-policy doc

### DIFF
--- a/docs/_docs/extras/minimal-deploy-iam.md
+++ b/docs/_docs/extras/minimal-deploy-iam.md
@@ -96,9 +96,10 @@ If your environment requires a "least privilege" approach, these commands will c
                     "lambda:GetFunction",
                     "lambda:CreateFunction",
                     "lambda:GetLayerVersion",
-                    "lambda:GetFunctionConfiguration",
                     "lambda:DeleteFunction",
+                    "lambda:UpdateFunctionCode",
                     "lambda:GetFunctionConfiguration",
+                    "lambda:UpdateFunctionConfiguration",
                     "lambda:AddPermission",
                     "lambda:RemovePermission",
                     "lambda:InvokeFunction"


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix. -->
<!-- This is a 🙋‍♂️ feature or enhancement. -->
This is a 🧐 documentation change.

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Added missing permissions to the least-privilege deployment permissions documentation.

I had to add both the `lambda:UpdateFunctionCode` and `lambda:UpdateFunctionConfiguration` actions in order to successfully run `jets deploy`.

## Context

N/A

## How to Test

I visually verified the change after running `bin/web` in the docs directory.

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

