### PR TITLE
pin to zeitwerk 2.4.x

### DIFF
--- a/jets.gemspec
+++ b/jets.gemspec
@@ -61,7 +61,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "shotgun"
   spec.add_dependency "text-table"
   spec.add_dependency "thor"
-  spec.add_dependency "zeitwerk"
+  spec.add_dependency "zeitwerk", "~> 2.4.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "byebug"


### PR DESCRIPTION
* preload removed in zeitwerk 2.5.x

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

https://github.com/fxn/zeitwerk/blob/main/CHANGELOG.md

Pin zeitwerk to 2.4.x until time to update to `loader.on_setup` method.

## How to Test

Run `jets server` and make sure app loads.

## Version Changes

Patch