### PR TITLE
method override also on the lambda function side

### DIFF
--- a/lib/jets/controller/rack/adapter.rb
+++ b/lib/jets/controller/rack/adapter.rb
@@ -5,13 +5,13 @@ module Jets::Controller::Rack
     extend Memoist
 
     # Returns back API Gateway response hash structure
-    def self.process(event, context, meth)
-      adapter = new(event, context, meth)
+    def self.process(event, context)
+      adapter = new(event, context)
       adapter.process
     end
 
-    def initialize(event, context, meth)
-      @event, @context, @meth = event, context, meth
+    def initialize(event, context)
+      @event, @context = event, context
     end
 
     # 1. Convert API Gateway event event to Rack env

--- a/lib/jets/controller/rack/env.rb
+++ b/lib/jets/controller/rack/env.rb
@@ -27,7 +27,7 @@ module Jets::Controller::Rack
     def path_with_base_path
       resource = @event['resource']
       pathParameters = @event['pathParameters']
-      
+
       if(!pathParameters.nil? and !resource.nil?)
         resource = pathParameters.reduce(resource) {|resource, parameter|
           key, value = parameter
@@ -64,7 +64,9 @@ module Jets::Controller::Rack
     end
 
     def content_type
-      headers['Content-Type'] || Jets::Controller::DEFAULT_CONTENT_TYPE
+      # Rack (local) uses Content-Type and APIGW (remote) uses content-type
+      # Rack::MethodOverride relys on content-type to detect content type properly.
+      headers['Content-Type'] || headers['content-type'] || Jets::Controller::DEFAULT_CONTENT_TYPE
     end
 
     def content_length

--- a/spec/lib/jets/controller/rack/adapter_spec.rb
+++ b/spec/lib/jets/controller/rack/adapter_spec.rb
@@ -1,8 +1,7 @@
 describe Jets::Controller::Rack::Adapter do
-  let(:adapter) { Jets::Controller::Rack::Adapter.new(event, context, meth) }
+  let(:adapter) { Jets::Controller::Rack::Adapter.new(event, context) }
   let(:context) { nil }
   let(:event) { json_file("spec/fixtures/dumps/api_gateway/posts/index.json") }
-  let(:meth)  { :index }
   let(:default_status) { 200 }
   let(:default_body) { StringIO.new(body_text) }
   let(:body_text) { 'Test body' }


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Also, override the method on the Lambda function side when request sends POST request with `_method=delete`. 

This removes the need for the `rubyonjets/ujs-compat` approach taken in #589

## Context

#589

## How to Test

Links like this should delete the record:

```html
<a class="button-to-link" rel="nofollow" data-method="delete" href="/posts/<%= post.id %>">
  <span class="some-css">delete</span>
</a>
```


## Version Changes

Patch