### PR TITLE
pin zeitwerk to 2.4.x in gemfile

### DIFF
--- a/lib/jets/commands/templates/skeleton/Gemfile.tt
+++ b/lib/jets/commands/templates/skeleton/Gemfile.tt
@@ -18,6 +18,7 @@ gem "mysql2", "~> 0.5.3"
 <% unless options[:mode] == 'job' -%>
 gem "dynomite"
 <% end -%>
+gem "zeitwerk", "~> 2.4.0"
 
 # development and test groups are not bundled as part of the deployment
 group :development, :test do


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Also pin zeitwerk to 2.4.x in the `jets new` generated `Gemfile`. 

## Context

#599 

## How to Test

    jets new demo
    jets server

Jets should load

## Version Changes

Patch