### PR TITLE
redirect_to: smarter handling of request xhr

### DIFF
--- a/lib/jets/generator/templates/rails/scaffold_controller/controller.rb
+++ b/lib/jets/generator/templates/rails/scaffold_controller/controller.rb
@@ -29,11 +29,7 @@ class <%= controller_class_name %>Controller < ApplicationController
     @<%= singular_table_name %> = <%= orm_class.build(class_name, "#{singular_table_name}_params") %>
 
     if @<%= orm_instance.save %>
-      if request.xhr?
-        render json: {success: true, location: url_for(@<%= singular_table_name %>)}
-      else
-        redirect_to <%= singular_table_name %>_path(@<%= singular_table_name %>)
-      end
+      redirect_to <%= singular_table_name %>_path(@<%= singular_table_name %>)
     else
       render :new
     end
@@ -42,11 +38,7 @@ class <%= controller_class_name %>Controller < ApplicationController
   # PUT <%= route_url %>/1
   def update
     if @<%= orm_instance.update("#{singular_table_name}_params") %>
-      if request.xhr?
-        render json: {success: true, location: url_for(@<%= singular_table_name %>)}
-      else
-        redirect_to <%= singular_table_name %>_path(@<%= singular_table_name %>)
-      end
+      redirect_to <%= singular_table_name %>_path(@<%= singular_table_name %>)
     else
       render :edit
     end
@@ -55,11 +47,7 @@ class <%= controller_class_name %>Controller < ApplicationController
   # DELETE <%= route_url %>/1
   def delete
     @<%= orm_instance.destroy %>
-    if request.xhr?
-      render json: {success: true, location: <%= table_name %>_path}
-    else
-      redirect_to <%= table_name %>_path
-    end
+    redirect_to <%= table_name %>_path
   end
 
 private

--- a/lib/jets/middleware/default_stack.rb
+++ b/lib/jets/middleware/default_stack.rb
@@ -13,7 +13,7 @@ module Jets::Middleware
         middleware.use Shotgun::Static
         middleware.use Rack::Runtime
         middleware.use Jets::Controller::Middleware::Cors if cors_enabled?
-        middleware.use Rack::MethodOverride # must come before Middleware::Local for multipart post forms to work
+        middleware.use Rack::MethodOverride unless ENV['JETS_RACK_METHOD_OVERRIDE'] == '0' # must come before Middleware::Local for multipart post forms to work
         middleware.use Jets::Controller::Middleware::Reloader if Jets.config.hot_reload
         middleware.use Jets::Controller::Middleware::Local # mimics AWS Lambda for local server only
         middleware.use session_store, session_options


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Make the `redirect_to` method smarter. It'll handle `request.xhr?`  automatically. This helps remove duplication in user's app code. So instead of:

```ruby
    if request.xhr?
      render json: {success: true, location: posts_path}
    else
      redirect_to posts_path
    end
```

It'll just be:

```ruby
    redirect_to posts_path
```

## How to Test

Generate new app and deploy it.

## Version Changes

Patch