### PR TITLE
fix redirect_to 301 and keep use default

### DIFF
--- a/lib/jets/controller/redirection.rb
+++ b/lib/jets/controller/redirection.rb
@@ -19,11 +19,11 @@ class Jets::Controller
         options[:status] = 200
         options[:body] = JSON.dump(success: true, location: redirect_url)
       else
-        options[:status] = 302
+        options[:status] = 301
         options[:body] = ""
       end
       Jets.logger.info("redirect_to options #{options}")
-      default.merge!(options)
+      options = default.merge(options)
 
       aws_proxy = Rendering::RackRenderer.new(self, options)
       resp = aws_proxy.render


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fix `redirect_to`

## Context

#603 

## How to Test

Generate new app and deploy it.

## Version Changes

Patch