### PR TITLE
use safer 302 redirect as default

### DIFF
--- a/lib/jets/controller/redirection.rb
+++ b/lib/jets/controller/redirection.rb
@@ -15,12 +15,12 @@ class Jets::Controller
         isBase64Encoded: false,
       }
       if request.xhr?
-        options[:content_type] = "application/json"
-        options[:status] = 200
-        options[:body] = JSON.dump(success: true, location: redirect_url)
+        options[:content_type] ||= "application/json"
+        options[:status] ||= 200
+        options[:body] ||= JSON.dump(success: true, location: redirect_url)
       else
-        options[:status] = 301
-        options[:body] = ""
+        options[:status] ||= 302
+        options[:body] ||= ""
       end
       Jets.logger.info("redirect_to options #{options}")
       options = default.merge(options)


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Use safer 302 for redirect_to.

## Context

* #603 
* #604 

## How to Test

Check that the header for a redirect has a 302 code.

## Version Changes

Patch