### PR TITLE
Job serialize

### DIFF
--- a/lib/jets/job/base.rb
+++ b/lib/jets/job/base.rb
@@ -26,13 +26,13 @@ module Jets::Job
       end
 
       def perform_now(meth, event={}, context={})
-        new(event.try(:to_unsafe_h), context, meth).send(meth)
+        new(event, context, meth).send(meth)
       end
 
       def perform_later(meth, event={}, context={})
         if on_lambda?
           function_name = "#{self.to_s.underscore}-#{meth}"
-          call = Jets::Commands::Call.new(function_name, JSON.dump(event.try(:to_unsafe_h)), invocation_type: "Event")
+          call = Jets::Commands::Call.new(function_name, JSON.dump(event), invocation_type: "Event")
           call.run
         else
           puts "INFO: Not on AWS Lambda. In local mode perform_later executes the job with perform_now instead."

--- a/spec/lib/jets/job/base_spec.rb
+++ b/spec/lib/jets/job/base_spec.rb
@@ -29,23 +29,11 @@ describe Jets::Job::Base do
       expect(resp).to eq(done: "digging")
     end
 
-    it "perform_now" do
-      resp = HardJob.perform_now(:dig, ActionController::Parameters.new(key1: "value1"))
-      expect(resp).to eq(done: "digging")
-    end
-
     it "perform_later" do
       allow(Jets::Commands::Call).to receive(:new).and_return(null)
       allow(HardJob).to receive(:on_lambda?).and_return(true)
       HardJob.perform_later(:dig, {})
       expect(Jets::Commands::Call).to have_received(:new)
-    end
-
-    it "perform_later" do
-      allow(Jets::Commands::Call).to receive(:new).and_return(null)
-      allow(HardJob).to receive(:on_lambda?).and_return(true)
-      expect(Jets::Commands::Call).to receive(:new).with('hard_job-dig', "{\"key1\":\"value1\"}", invocation_type: "Event")
-      HardJob.perform_later(:dig, ActionController::Parameters.new(key1: "value1"))
     end
   end
 


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Reverting #596 This is making the event payload come in as empty.

app/jobs/hard_job.rb:

```ruby
class HardJob < ApplicationJob
  rate "10 hours" # every 10 hours
  def dig
    puts "done digging: #{event}"
  end
end
```

Then in a jets console:

    $ jets c
    > HardJob.perform_now(:dig, test: 1)
    done digging: {}
     => nil 

## Context

#596 

## How to Test

Confirm in a jets console that the event from a job is not empty.

## Version Changes

Patch